### PR TITLE
Refactor language picker using icon component

### DIFF
--- a/_includes/components/icon-list.html
+++ b/_includes/components/icon-list.html
@@ -8,7 +8,7 @@ include
   {% for item in include.items %}
     <li class="usa-icon-list__item">
       <div class="usa-icon-list__icon text-{{ include.icon_color }}">
-        {% include components/icon.html shape=include.icon_shape %}
+        {% include components/icon.html icon=include.icon_shape %}
       </div>
       <div class="usa-icon-list__content">
         {{ item |markdownify | remove: '<p>' | remove: '</p>' }}

--- a/_includes/components/icon.html
+++ b/_includes/components/icon.html
@@ -1,3 +1,17 @@
-<svg class="usa-icon" aria-hidden="true" role="img">
-  <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#{{ include.shape }}"></use>
+{% comment %}
+include
+- icon
+- size
+{% endcomment %}
+
+{% assign class = 'usa-icon' %}
+{% if include.size > 1 %}
+  {% assign class = class | append: ' usa-icon--size-' | append: include.size %}
+{% endif %}
+{% if include.class %}
+  {% assign class = class | append: ' ' | append: include.class %}
+{% endif %}
+
+<svg class="{{ class }}" aria-hidden="true" role="img">
+  <use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#{{ include.icon }}"></use>
 </svg>

--- a/_includes/language_picker.html
+++ b/_includes/language_picker.html
@@ -4,10 +4,11 @@
       aria-controls="language-picker-{{ include.id }}"
       class="usa-accordion__button language-picker__label language-picker__label--button"
     >
-      <img src="{{ site.baseurl }}/assets/img/globe-blue.svg" alt="" width="12" height="12">
-      <span id="language-picker-{{ include.id }}-description">
+      {% include components/icon.html icon='language' %}
+      <span id="language-picker-{{ include.id }}-description" class="language-picker__label-text">
         {{ site.data.[page.lang].settings.global.language }}
       </span>
+      {% include components/icon.html icon='expand_more' size=3 class='language-picker__expander' %}
     </button>
   {% else %}
     <div class="language-picker__label language-picker__label--text">

--- a/_sass/components/_language-picker.scss
+++ b/_sass/components/_language-picker.scss
@@ -36,22 +36,30 @@
 .language-picker__label--button {
   @include typeset($theme-button-font-family, null, 1);
   @include u-radius($theme-button-border-radius);
-  background-position: right units(1.5) center;
-  background-position-y: calc(50% + 2px);
-  padding: units(1.5);
-  padding-right: units(3);
+  padding: units(1);
+  padding-left: units(1.5);
 
   &.usa-accordion__button[aria-expanded='false'],
   &.usa-accordion__button[aria-expanded='true'] {
-    background-size: 0.8125rem;
+    background-image: none;
   }
 
-  &.usa-accordion__button[aria-expanded='false'] {
-    background-image: url(../img/angle-arrow-down.svg);
+  .language-picker__label-text {
+    margin-left: units(1);
+    margin-right: units(0.5);
+  }
+}
+
+.language-picker__expander {
+  margin: -1px 0;
+  transition: transform $project-easing;
+
+  @media (prefers-reduced-motion) {
+    transition: none;
   }
 
-  &.usa-accordion__button[aria-expanded='true'] {
-    background-image: url(../img/angle-arrow-up.svg);
+  .usa-accordion__button[aria-expanded='true'] & {
+    transform: rotate(-180deg);
   }
 }
 


### PR DESCRIPTION
## 🛠 Summary of changes

Refactors the language picker to use [the design system icon component](https://designsystem.digital.gov/components/icon/) instead of ad hoc images.

This is an incremental step toward upgrading to [the latest version of the design system](https://github.com/18F/identity-design-system/releases/tag/v9.0.0), which removes the images `angle-arrow-down.svg` and `angle-arrow-up.svg` which are updated here.

This also aligns to the IdP implementation introduced in https://github.com/18F/identity-idp/pull/10098, including improvements there to add an animation to the toggle, as well as avoiding flickering appearance of an image when first toggling the dropdown.

## 📜 Testing Plan

Verify that there are no regressions in the appearance or function of the language picker. Note that there are different language picker interactions between desktop (dropdown) and mobile (static list of options within menu).

Live preview: https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/aduth-language-picker-icons/

## 📸 Screenshots

There may be subtle differences in the appearance of the icons due to differences in the icon implementation, which are expected and an improvement over the current appearance, notably in vertical centering and consistency in height between the selector and the "Sign in with Login.gov" button.

**Desktop:**

Before|After
---|---
![image](https://github.com/GSA-TTS/identity-site/assets/1779930/328183df-a9c8-461c-acc3-2f36cbaf253b)|![image](https://github.com/GSA-TTS/identity-site/assets/1779930/d30f7d3f-f01a-4d71-8624-f39c8047825b)

Before|After
---|---
![image](https://github.com/GSA-TTS/identity-site/assets/1779930/0000050d-8c37-4514-87f9-d71248dd5beb)|![image](https://github.com/GSA-TTS/identity-site/assets/1779930/0b3c09bd-5803-4042-ae32-bf6192788f87)


**Mobile:** (identical)

Before|After
---|---
![image](https://github.com/GSA-TTS/identity-site/assets/1779930/83097e55-f9a1-461d-a5a8-24fffe3f121c)|![image](https://github.com/GSA-TTS/identity-site/assets/1779930/91ad3789-fcc5-4064-8202-25a049529162)

cc @nickttng 