### PR TITLE
Replace raw color tokens with stateful alternatives

### DIFF
--- a/content/_help/verify-your-identity/accepted-identification-documents._en.md
+++ b/content/_help/verify-your-identity/accepted-identification-documents._en.md
@@ -10,7 +10,7 @@ redirect_from:
   - /en/help/verify-your-identity/accepted-identification-documents/
   - /help/verify-your-identity/accepted-state-issued-identification/
   - /en/help/verify-your-identity/accepted-state-issued-identification/
-do_list: 
+do_list:
   - "**Driver’s license** from all 50 states, the District of Columbia (DC), and other U.S. territories (Guam, U.S. Virgin Islands, American Samoa, Mariana Islands, and Puerto Rico)."
   - "**Non-driver’s license state-issued ID card.** This is an identity document issued by the state, the District of Columbia (DC), or U.S. territory that asserts identity but does not give driving privileges."
 dont_list:
@@ -20,14 +20,14 @@ dont_list:
 alert: <strong>If you do not have a valid driver's license or state ID card, you cannot use Login.gov for identity verification.</strong> Please contact the partner agency’s help center to find out what you can do instead.
 ---
 
-{% include components/icon-list.html items=page.do_list size='md' icon_color='green' icon_shape='check_circle'%}
+{% include components/icon-list.html items=page.do_list size='md' icon_color='success' icon_shape='check_circle'%}
 
 ## We do not accept military IDs, U.S. Passports, or other identification documents.
 
 {% include alert.html content=page.alert type='error' role='alert' %}
 
 
-{% include components/icon-list.html items=page.dont_list size='md' icon_color='red' icon_shape='cancel' %}
+{% include components/icon-list.html items=page.dont_list size='md' icon_color='error' icon_shape='cancel' %}
 
 ## Related articles 
 

--- a/content/_help/verify-your-identity/accepted-identification-documents._es.md
+++ b/content/_help/verify-your-identity/accepted-identification-documents._es.md
@@ -17,14 +17,14 @@ dont_list:
   - No, no puede usar un documento de identidad temporal o&nbsp;de&nbsp;papel.
 ---
 
-{% include components/icon-list.html items=page.do_list size='md' icon_color='green' icon_shape='check_circle'  %}
+{% include components/icon-list.html items=page.do_list size='md' icon_color='success' icon_shape='check_circle'  %}
 
 ## No aceptamos cartillas militares, pasaportes estadounidenses ni otros documentos de identificación.
 
 
 {% include alert.html content=page.alert type='error' role='alert' %}
 
-{% include components/icon-list.html items=page.dont_list size='md' icon_color='red' icon_shape='cancel' %}
+{% include components/icon-list.html items=page.dont_list size='md' icon_color='error' icon_shape='cancel' %}
 
 ## Artículos relacionados
 

--- a/content/_help/verify-your-identity/accepted-identification-documents._fr.md
+++ b/content/_help/verify-your-identity/accepted-identification-documents._fr.md
@@ -17,13 +17,13 @@ dont_list:
   - Non, vous ne pouvez pas utiliser de carte d'identité en format papier ou temporaire.
 ---
 
-{% include components/icon-list.html items=page.do_list size='md' icon_color='green' icon_shape='check_circle' %}
+{% include components/icon-list.html items=page.do_list size='md' icon_color='success' icon_shape='check_circle' %}
 
 ## Nous n’acceptons pas les cartes d’identité militaires, les passeports américains ou autres documents d’identification.
 
 {% include alert.html content=page.alert type='error' role='alert' %}
 
-{% include components/icon-list.html items=page.dont_list size='md' icon_color='red' icon_shape='cancel' %}
+{% include components/icon-list.html items=page.dont_list size='md' icon_color='error' icon_shape='cancel' %}
 
 
 ## Articles connexes

--- a/content/_help/verify-your-identity/how-to-add-images-of-your-state-issued-id._en.md
+++ b/content/_help/verify-your-identity/how-to-add-images-of-your-state-issued-id._en.md
@@ -7,7 +7,7 @@ order: 3
 redirect_from:
   - /en/help/verify-your-identity/how-to-add-images-of-your-state-issued-id/
   - /help/verify-your-identity/troubleshoot-uploading-your-state-issued-id/
-do_list: 
+do_list:
   - Do use a high resolution camera like a smartphone or tablet camera. Your computer webcam may not take clear photos.
   - Do use a solid, dark background.
   - Do take your photos in a well-lit area with indirect light.
@@ -60,7 +60,7 @@ If you are using a computer to verify your identity, you will be able to switch 
   include components/icon-list.html
   items=page.do_list
   size='md'
-  icon_color='green'
+  icon_color='success'
   icon_shape='check_circle'
 %}
 
@@ -110,7 +110,7 @@ If you are using a computer to verify your identity, you will be able to switch 
   </div>
 </div>
 
---- 
+---
 
 ## If you don’t have access to a phone with a camera, you can upload a file or use a scanner
 * Follow the same [tips for taking photos with a phone](#phone-tips).

--- a/content/_help/verify-your-identity/how-to-add-images-of-your-state-issued-id._es.md
+++ b/content/_help/verify-your-identity/how-to-add-images-of-your-state-issued-id._es.md
@@ -7,7 +7,7 @@ order: 3
 redirect_from:
   - /es/help/verify-your-identity/how-to-add-images-of-your-state-issued-id/
   - /es/help/verify-your-identity/troubleshoot-uploading-your-state-issued-id/
-do_list: 
+do_list:
   - Es recomendable utilizar una cámara de alta resolución, como la de un smartphone o una tableta. Es probable que la cámara web de tu computadora no pueda obtener fotografías nítidas.
   - Utiliza un fondo sólido y oscuro.
   - Procura realizar las fotografías en una zona bien iluminada y con luz indirecta.
@@ -60,7 +60,7 @@ Si está utilizando una computadora para verificar su identidad, puede cambiar a
   include components/icon-list.html
   items=page.do_list
   size='md'
-  icon_color='green'
+  icon_color='success'
   icon_shape='check_circle'
 %}
 

--- a/content/_help/verify-your-identity/how-to-add-images-of-your-state-issued-id._fr.md
+++ b/content/_help/verify-your-identity/how-to-add-images-of-your-state-issued-id._fr.md
@@ -7,7 +7,7 @@ order: 3
 redirect_from:
   - /fr/help/verify-your-identity/how-to-add-images-of-your-state-issued-id/
   - /fr/help/verify-your-identity/troubleshoot-uploading-your-state-issued-id/
-do_list: 
+do_list:
   - Utilisez une caméra à haute résolution telle qu'une caméra de téléphone intelligent ou de tablette. La webcaméra de votre ordinateur risque de ne pas prendre de photos claires.
   - Utilisez un fond solide et sombre.
   - Prenez vos photos dans un endroit bien éclairé avec une lumière indirecte.
@@ -60,7 +60,7 @@ Si vous utilisez un ordinateur pour vérifier votre identité, vous pourrez pass
   include components/icon-list.html
   items=page.do_list
   size='md'
-  icon_color='green'
+  icon_color='success'
   icon_shape='check_circle'
 %}
 


### PR DESCRIPTION
## 🛠 Summary of changes

Replaces instances of "green" and "red" design system color tokens with equivalent "success" and "error" tokens.

This is an incremental step toward upgrading to [the latest version of the design system](https://github.com/18F/identity-design-system/releases/tag/v9.0.0), which removes raw color tokens. As noted in the CHANGELOG, these colors are also incorrect.

## 📜 Testing Plan

1. Visit affected pages to verify that the icon list icons appear in the expected green and red colors:
   1. https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/aduth-stateful-colors/help/verify-your-identity/accepted-identification-documents/
   2. https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/aduth-stateful-colors/help/verify-your-identity/how-to-add-images-of-your-state-issued-id/

## 📸 Screenshots

As noted above, the raw color tokens have always been slightly inconsistent with the expected stateful colors, so there is expected to be a slight color difference here.

Before|After
---|---
![image](https://github.com/GSA-TTS/identity-site/assets/1779930/f8cc4983-c454-473e-81ce-0a7e2bc94a1a)|![image](https://github.com/GSA-TTS/identity-site/assets/1779930/0fe76d7d-8cff-4f49-a167-a2922bfb8276)

cc for review: @night-jellyfish @charleyf @dawei-nava 