### PR TITLE
Conditionally render analytics / reCAPTCHA if configured

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,6 @@ languages:
 exclude_from_localizations: ['javascript', 'images', 'css']
 
 # Contact form production values (overridden in Cloud.gov Pages for preview branches)
-contact_form_captcha_enabled: true
 contact_form_action: 'https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8'
 contact_form_orgid: '00DU0000000Leux'
 
@@ -29,8 +28,18 @@ contact_maintenance_phone_available: true
 contact_unplanned_outage: false
 contact_unplanned_outage_phone_available: false
 
+# Digital Analytics Program
+dap_agency: null
+dap_subagency: null
+
 # GSA Office of Strategic Communication (OSC) Google Analytics
 osc_analytics_ga_measurement_id: null
+
+# TTS Google Analytics
+tts_ga_ua_id: null
+
+# Google reCAPTCHA
+recaptcha_site_key: null
 
 # Used to load country code support
 idp_base_url: https://secure.login.gov

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -412,9 +412,9 @@
     <input type="hidden" name="status" id="status" value="New" />
     <input type="hidden" id="external" name="external" value="1" />
     <input type="hidden" name="recordType" id="recordType" value="012t00000004JFu" />
-    {% if site.contact_form_captcha_enabled != true %}
+    {% unless site.recaptcha_site_key %}
     <input type="hidden" name="debug" value="1" />
-    {% endif %}
+    {% endunless %}
 
     <p>
       {{ site.data.[page.lang].settings.contact_page.operating_hours }}
@@ -561,17 +561,17 @@
     </div>
     <!-- END: Description -->
 
-    {% if site.contact_form_captcha_enabled %}
+    {% if site.recaptcha_site_key %}
     <!-- START: reCAPTCHA -->
     <div
       class="g-recaptcha margin-top-4"
-      data-sitekey="6LfeV8YUAAAAAObO6JWt4FUMJUmzbjkufn09mgtl"
+      data-sitekey="{{ site.recaptcha_site_key }}"
       data-callback="clearCaptchaError"
     ></div>
     <input
       type="hidden"
       name="captcha_settings"
-      value='{"keyname":"ReCAPTCHA_Login","fallback":"true","orgId":"00DU0000000Leux","ts":""}'
+      value='{"keyname":"ReCAPTCHA_Login","fallback":"true","orgId":"{{ site.contact_form_orgid }}","ts":""}'
     />
     <div
       id="captcha-error-message"

--- a/_includes/dap.html
+++ b/_includes/dap.html
@@ -1,7 +1,9 @@
+{% if site.dap_agency and site.dap_subagency %}
 <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
 <script
   async
   type="text/javascript"
-  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=TTS"
+  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency={{ site.dap_agency }}&subagency={{ site.dap_subagency }}"
   id="_fed_an_ua_tag"
 ></script>
+{% endif %}

--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,3 +1,4 @@
+{% if site.tts_ga_ua_id %}
 <!-- Initialize analytics for the TTS Google Analytics account -->
 <script>
   (function (i, s, o, g, r, a, m) {
@@ -19,8 +20,9 @@
     "https://www.google-analytics.com/analytics.js",
     "ga"
   );
-  ga("create", "UA-48605964-44", "auto");
+  ga("create", "{{ site.tts_ga_ua_id }}", "auto");
   ga("set", "anonymizeIp", true);
   ga("set", "forceSSL", true);
   ga("send", "pageview");
 </script>
+{% endif %}

--- a/_includes/google_recaptcha.html
+++ b/_includes/google_recaptcha.html
@@ -1,3 +1,4 @@
+{% if site.recaptcha_site_key and site.recaptcha_org_id %}
 <script src="https://www.google.com/recaptcha/api.js"></script>
 <script>
   function timestamp() {
@@ -14,3 +15,4 @@
   }
   setInterval(timestamp, 500);
 </script>
+{% endif %}

--- a/_includes/osc_analytics.html
+++ b/_includes/osc_analytics.html
@@ -1,3 +1,4 @@
+{% if site.osc_analytics_ga_measurement_id %}
 <!-- Analytics for GSA's Office of Strategic Communication (OSC) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.osc_analytics_ga_measurement_id }}"></script>
 <script>
@@ -6,3 +7,4 @@ function gtag() { dataLayer.push(arguments); }
 gtag('js', new Date());
 gtag('config', '{{ site.osc_analytics_ga_measurement_id }}');
 </script>
+{% endif %}

--- a/_includes/partners/contact.html
+++ b/_includes/partners/contact.html
@@ -21,9 +21,9 @@
     method="POST"
     class="usa-form"
     >
-    {% if site.contact_form_captcha_enabled != true %}
+    {% unless site.recaptcha_site_key %}
     <input type="hidden" name="debug" value="1" />
-    {% endif %}
+    {% endunless %}
 
     <p class="partners-subtitle">
       Login.gov provides authentication and identity verification services to federal
@@ -383,17 +383,17 @@
           ></textarea>
     </div>
 
-    {% if site.contact_form_captcha_enabled %}
+    {% if site.recaptcha_site_key %}
     <!-- START: reCAPTCHA -->
     <div
         class="g-recaptcha margin-top-4"
-        data-sitekey="6LfeV8YUAAAAAObO6JWt4FUMJUmzbjkufn09mgtl"
+        data-sitekey="{{ site.recaptcha_site_key }}"
         data-callback="clearCaptchaError"
         ></div>
     <input
         type="hidden"
         name="captcha_settings"
-        value='{"keyname":"ReCAPTCHA_Login","fallback":"true","orgId":"00DU0000000Leux","ts":""}'
+        value='{"keyname":"ReCAPTCHA_Login","fallback":"true","orgId":"{{ site.contact_form_orgid }}","ts":""}'
         />
     <div
         id="captcha-error-message"


### PR DESCRIPTION
Blocks #1222

## 🛠 Summary of changes

Avoids rendering various analytics and reCAPTCHA scripts unless configured for the environment.

This avoids local development or test environments from unnecessarily loading analytics or affecting logged data. It also avoids keeping configuration out of source control and avoids hard-coding them into the templates.

It supports #1222 by fixing console errors which occur locally when trying to load these scripts.

## 📜 Testing Plan

Verify by default no analytics are rendered by the affected scripts (DAP, TTS GA, GSA OSC GA, reCAPTCHA).

Use sample values for each of the configurations and confirm that the scripts are included after configured.

These configurations will need to be implemented in Cloud.gov Pages site settings before merge.