### PR TITLE
Hide accordion content while JavaScript loads

### DIFF
--- a/_includes/language_picker.html
+++ b/_includes/language_picker.html
@@ -2,6 +2,7 @@
   {% if include.dropdown == true %}
     <button
       aria-controls="language-picker-{{ include.id }}"
+      aria-expanded="false"
       class="usa-accordion__button language-picker__label language-picker__label--button"
     >
       {% include components/icon.html icon='language' %}

--- a/_sass/components/_accordion.scss
+++ b/_sass/components/_accordion.scss
@@ -1,0 +1,11 @@
+@use 'uswds-core' as *;
+
+// Upstream: https://github.com/uswds/uswds/pull/5826
+.usa-js-loading {
+  .usa-accordion {
+    &:has([aria-expanded='false']) + .usa-accordion__content,
+    [aria-expanded='false'] + .usa-accordion__content {
+      @include add-sr-only;
+    }
+  }
+}

--- a/_sass/components/all.scss
+++ b/_sass/components/all.scss
@@ -1,3 +1,4 @@
+@forward 'accordion';
 @forward 'already-have-an-account';
 @forward 'banner';
 @forward 'card';


### PR DESCRIPTION
## 🛠 Summary of changes

This enhances accordion styles to appear hidden while JavaScript is loaded if expected to be collapsed once JavaScript finishes loading.

The benefit is that this avoids the appearance of flashing content. This is especially noticeable with the language picker element, which is implemented as an accordion and is displayed at the top of the page.

See upstream pull request: https://github.com/uswds/uswds/pull/5826

## 📜 Testing Plan

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/aduth-accordion-js-loading/
2. Refresh the page with cache disabled (either hard refresh with <kbd>Shift</kbd><kbd>⌘</kbd><kbd>R</kbd> in Chrome, or "Disable cache" in the Network tab of developer tools)
3. Observe that the language picker always appears collapsed and that its contents do not flash visible at any point
4. Verify there is otherwise no change in behavior of using the language picker

## 📸 Screenshots

Before:

https://github.com/GSA-TTS/identity-site/assets/1779930/a369d37f-4adc-4aa9-8652-2ca456f6100c

After:

https://github.com/GSA-TTS/identity-site/assets/1779930/cfab56f4-d533-46a5-b36e-c8d5ff5430e4