### PR TITLE
Remove unused data keys

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -340,37 +340,3 @@ nav:
   system_status: Login.gov system status
   what_is_login_gov: What is Login.gov?
   who_uses_login_gov: Who uses Login.gov?
-policies:
-  sections:
-    - name: Our commitment to your privacy and security
-      sublinks:
-        - text: How we work with our partner agencies
-          url: '#how-we-work-with-our-partner-agencies'
-      url: '/policy/'
-    - name: How does it work?
-      url: '/policy/how-does-it-work/'
-    - name: Our privacy act statement
-      sublinks:
-        - text: The Authority - Who authorizes the collection of this data?
-          url: '#authority'
-        - text: The Purpose - Why do we need your information?
-          url: '#purpose'
-        - text: Routine Uses - With whom is the information routinely shared?
-          url: '#routine-uses'
-        - text: Consent - How can you control what information is shared?
-          url: '#consent'
-        - text: Records - Where can you find more information?
-          url: '#records'
-        - text: Website Analytics
-          url: '#analytics'
-        - text: Privacy Impact Assessment
-          url: '#impact'
-      url: '/policy/our-privacy-act-statement/'
-    - name: Messaging terms and conditions
-      sublinks:
-        - text: SMS terms and conditions
-          url: '#terms'
-      url: '/policy/messaging-terms-and-conditions/'
-    - name: Rules of use
-      url: '/policy/rules-of-use/'
-  title: Privacy & security

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -89,7 +89,6 @@ contact_page:
       'Peace Corps': Cuerpo de Paz
       'Railroad Retirement Board': Junta de Jubilación del Ferrocarril
       'SBA DLAP': SBA DLAP
-      'Securities and Exchange Commision': Comisión de Bolsa y Valores
       'Securities and Exchange Commission': Comisión de Bolsa y Valores
       'Social Security Administration (SSA)': Administración del Seguro Social (SSA, por su siglas en inglés)
       'State of Arkansas': Estado de Arkansas
@@ -119,7 +118,6 @@ contact_page:
       email: Correo electrónico
       first_name: Nombre
       last_name: Apellido
-      optional: opcional
       pii_warning: 'No incluya números de teléfono, números de socio, nombres
         completos, cumpleaños, direcciones, números de la seguridad social u
         otros datos identificativos.'
@@ -211,8 +209,6 @@ feedback_form:
   'no': 'No'
   question: ¿Te resultó útil este artículo?
   'yes': 'Si'
-footer:
-  gsa: Administración General de Servicios de EE. UU.
 global:
   language: Idioma
   locales:
@@ -359,37 +355,3 @@ nav:
   system_status: Estado del sistema Login.gov
   what_is_login_gov: ¿Qué es Login.gov?
   who_uses_login_gov: ¿Quién usa Login.gov?
-policies:
-  sections:
-    - name: Nuestro compromiso con su privacidad y seguridad
-      sublinks:
-        - text: Cómo trabajamos con nuestras agencias asociadas
-          url: '#how-we-work-with-our-partner-agencies'
-      url: '/policy/'
-    - name: ¿Cómo funciona?
-      url: '/policy/how-does-it-work/'
-    - name: Nuestra declaración de la ley de privacidad
-      sublinks:
-        - text: La Autoridad - ¿Quién autoriza la recopilación de estos datos?
-          url: '#authority'
-        - text: El propósito - ¿Por qué necesitamos su información?
-          url: '#purpose'
-        - text: Usos de rutina - ¿Con quién se comparte habitualmente la información?
-          url: '#routine-uses'
-        - text: Consentimiento - ¿Cómo puede controlar qué información se comparte?
-          url: '#consent'
-        - text: Registros - ¿Dónde puede encontrar más información?
-          url: '#records'
-        - text: Análisis de sitios web
-          url: '#analytics'
-        - text: Evaluación del impacto en la privacidad
-          url: '#impact'
-      url: '/policy/our-privacy-act-statement/'
-    - name: Términos y condiciones de mensajería
-      sublinks:
-        - text: Términos y condiciones de SMS
-          url: '#terms'
-      url: '/policy/messaging-terms-and-conditions/'
-    - name: Reglas de uso
-      url: '/policy/rules-of-use/'
-  title: Privacidad y seguridad

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -114,7 +114,6 @@ contact_page:
       email: E-mail
       first_name: Prénom
       last_name: Nom
-      optional: optionnel
       pii_warning: N’incluez pas les numéros de téléphone, les numéros de membre, les
         noms complets, les anniversaires, les adresses, les numéros de sécurité
         sociale ou toute autre information permettant d’identifier les
@@ -208,8 +207,6 @@ feedback_form:
   'no': 'Non'
   question: Cet article vous a-t-il été utile?
   'yes': 'Oui'
-footer:
-  gsa: Administration des services généraux des États-Unis
 global:
   language: Langue
   locales:
@@ -355,123 +352,3 @@ nav:
   system_status: État du système Login.gov
   what_is_login_gov: Qu’est-ce que Login.gov?
   who_uses_login_gov: Qui utilise Login.gov?
-policies:
-  heading_1: Les principes du guide de mise en œuvre de l’identité
-  heading_2: Axé sur les besoins des utilisateurs
-  heading_3: Être transparent sur le fonctionnement
-  heading_4: Bâtir un produit flexible
-  heading_5: Utiliser des pratiques de confidentialité modernes
-  heading_6: Créer des systèmes de sécurité réactifs
-  p_1: |-
-    Résoudre des problèmes réels pour les utilisateurs potentiels doit être l’objectif principal de tout système et est doublement important dans la construction d’un système de gestion d’identité. Tout au long de ce guide, vous constaterez à quel point les besoins des utilisateurs constituent un principe directeur pour chaque prise de décision.
-
-    Une des premières étapes que vous devez effectuer est d’identifier vos utilisateurs principaux. Pour Login.gov, nous avons identifié deux groupes comme étant nos utilisateurs principaux: le public et les experts en technologie faisant partie des agences gouvernementales. L’objectif pour le système en soi est de fournir de l’assistance et de répondre aux besoins du public. En bref, nous souhaitons nous assurer que notre système rend les gens à l’aise avec la connexion aux services gouvernementaux. Le public doit avoir confiance que Login.gov se comporte comme prévu et qu’il ne les décevra pas. Le système doit aussi aborder l’expérience entière des utilisateurs alors qu’ils tentent d’accomplir leurs objectifs. Parce que la vérification de l’identité et l’authentification sont technologiquement complexes, il est probable que même les personnes les plus aguérries en ce qui a trait aux technologies peuvent rester piégées si leur téléphone est perdu ou si un système comporte des erreurs. Alors, en soutien à la mission de chaque agence, les architectes et les concepteurs des systèmes de gestion de l’identité doivent anticiper les points probables de friction afin que les utilisateurs ne perdent pas leur accès aux services et aux avantages.
-
-    Les agences doivent identifier la portion du public qu’elles desservent et comment les services peuvent être bâtis pour répondre spécifiquement à leurs besoins. Ceci aidera les équipes d’intégration des agences à comprendre ce dont ils ont besoin si elles décident de mettre en œuvre la plate-forme Login.gov ou tout autre système de gestion d’identité du consommateur.
-
-    Enfin, vous devez constamment tester les designs et outils au moment où ils sont prêts à être partagés et ensuite ajuster votre projet en fonction de ce que vous avez appris. Dans certains cas, nous apprenons que les meilleures pratiques actuelles ne sont pas adéquates. Et dans ces cas, nous sommes poussés à essayer de nouvelles façons de donner aux utilisateurs la meilleure expérience possible. Ce processus implique plus de tests, l’éducation des utilisateurs et une volonté à itérer.
-
-    Il existe un nombre de méthodes de conception spécifiques que nous mettons en pratique pour demeurer axés sur l’utilisateur et vous pouvez lire au sujet de tous ces processus et les utiliser en passant en revue le [18F Design Methods](https://methods.18f.gov/).
-  p_2: |-
-    [Travailler de façon transparente](https://playbook.cio.gov/#play13) et créer un système transparent devrait être la façon dont toute agence travaille pour bâtir ou mettre en œuvre un système de gestion d’identité. Pour exécuter ce principe avec Login.gov, nous bâtissons la plate-méthode de manière à ce que les parties intéressées puisse nous conseiller sur les meilleures pratiques afin que nous demeurions responsables envers le public et envers nos partenaires de toutes les agences gouvernementales. De plus, cela signifie qu’un système qui indique aux utilisateurs ce qu’il fait de leur information dans le but de créer une responsabilisation et établir une confiance. Nous impliquons les utilisateurs et autres parties intéressées par le biais de notre [référentiel GitHub](https://github.com/18F/identity-idp) et travaillons à la création de forums publics où les utilisateurs peuvent discuter de notre travail.
-
-    Afin de rendre un système de gestion d’identité transparent pour les utilisateurs finaux, le système doit inclure des fonctionnalités qui éduquent les gens sur la façon dont le système fonctionne, pourquoi il fonctionne de cette façon et de quelle manière ils peuvent contrôler ce qui advient de leurs données. Vous devriez aussi informer les utilisateurs de l’information qui est requise par une agence pour la connexion à un service. Il est aussi important d’informer les utilisateurs de quelle information vos systèmes stockeront et si toute donnée est partagée avec les autres agences. Si les gens qui utilisent le système ne sont pas à l’aise avec le partage d’information, ils ne doivent pas être obligés de participer.
-
-    Login.gov travaille pour mettre en œuvre toutes ces fonctionnalités ayant pour but d’améliorer la transparence. De plus, pour aider les gens à comprendre tout le processus, nous créons une politique de confidentialité qui explique comment les données sont partagées et ce que signifie de choisir l’option de retrait.
-  p_3: |-
-    La technologie et les normes pour de la vérification d’identité peuvent changer rapidement. La gestion de l’identité du consommateur doit s’adapter rapidement aux normes changeantes et réagir aux nouvelles menaces à la sécurité. Afin de rendre l’adaptation aux nouvelles politiques et aux capacités possible, il s’agit d’une bonne pratique de bâtir des produits en utilisant des méthodes agiles qui tiennent compte des versions changeantes. En d’autres termes, planifier les modifications pour aider votre service d’identité à être aussi à jour et conforme que possible aux normes et politiques actuelles.
-
-    Nous adhérons à ce principe pour chaque aspect des projets qui construisent Login.gov.
-
-    [Lisez ce guide](https://pages.18f.gov/agile/index.html) des principes et pratiques agiles élaborés par l’équipe 18F pour en savoir plus sur ce que signifie de travailler de façon agile.
-  p_4: |-
-    Les systèmes de gestion d’identité stockent l’information personnelle sur les utilisateurs afin que les gens n’aient pas à répéter sans cesse les processus de vérification et d’authentification. Toutefois, recueillir et stocker de l’information personnelle sou;ève des questions éthiques et légales que les concepteurs de systèmes et les développeurs doivent considérer. Souvent, ce qui vient d’abord à l’esprit sont les questions techniques sur la sécurité : la protection de l’information contre les usages non autorisés et illégaux. Toutefois, nous devons aussi nous préoccuper des usages autorisés et légaux de l’information personnelle qui violent les attentes des utilisateurs en matière de confidentialité. Les utilisateurs de Login.gov doivent être assurés que nous gérons leur information personnelle de façon respectueuse et appropriée.
-
-    La première étape est de recueillir seulement l’information dont vous avez absolument besoin. Et c’est ce que fait Login.gov. La vérification d’identité à assurance élevée pour les tâches sensibles requiert une collecte d’information exhaustive. Cependant, de nombreuses activités ne requièrent pas des niveaux élevés d’assurance (NEA) et Login.gov prend en charge différents LOA afin que les agences puissent clairement délimiter leurs utilisateurs qui ont besoin d’un niveau de sécurité plus bas de ceux qui ont des besoins plus sensibles tout en assurant l’utilisabilité et la sécurité des données. Minimiser la quantité d’information recueillie et stockée ne réduit pas seulement les risques liés à la sécurité; cela réduit aussi pour les utilisateurs les craintes liées à la réutilisation et la divulgation.
-
-    La prochaine étape est de donner aux utilisateurs autant de contrôle que possible sur l’information qui est partagée. Nous croyons fermement que les gens possèdent leurs propres données, pas nous, et nous agirons toujours en conséquence. Si les utilisateurs ne sont pas à l’aise avec les demandes de données pour l’utilisation du système, ils doivent savoir qu’ils n’ont pas à s’inscrire et qu’il existe d’autres moyens d’atteindre leurs objectifs.
-
-    Au fur et à mesure que nous faisons la conception de Login.gov, nous travaillons également à éduquer les utilisateurs pour les aider à sécuriser leurs propres données. Nous souhaitons que les gens comprennent pourquoi nous devons demander certains types d’information, comme les numéros de sécurité sociale, et comment nous les utilisons.
-  sections:
-    - link:
-        text: Notre engagement envers votre confidentialité et votre sécurité
-        url: '/policy/'
-      sublinks:
-        - text: Comment nous travaillons avec nos agences partenaires
-          url: '#how-we-work-with-our-partner-agencies'
-    - link:
-        text: Comment ça marche?
-        url: '/policy/how-does-it-work/'
-    - link:
-        text: Notre déclaration de confidentialité
-        url: '/policy/our-privacy-act-statement/'
-      sublinks:
-        - text: L’Autorité - Qui autorise la collecte de ces données?
-          url: '#authority'
-        - text: The Purpose - Pourquoi avons-nous besoin de vos informations?
-          url: '#purpose'
-        - text: Usages courants - Avec qui les informations sont-elles communément
-            partagées?
-          url: '#routine-uses'
-        - text: Consentement - Comment pouvez-vous contrôler quelles informations sont
-            partagées?
-          url: '#consent'
-        - text: Records - Où trouver plus d’informations?
-          url: '#records'
-        - text: Analyse du site Web
-          url: '#analytics'
-        - text: Évaluation des facteurs relatifs à la vie privée
-          url: '#impact'
-    - link:
-        text: Termes et conditions de la messagerie
-        url: '/policy/messaging-terms-and-conditions/'
-      sublinks:
-        - text: Termes et conditions SMS
-          url: '#terms'
-    - link:
-        text: Règles d’utilisation
-        url: '/policy/rules-of-use/'
-  title: Confidentialité et sécurité
-  ul_1:
-    li_1: Identifier vos auditoires potentiels
-    li_2: Comprendre les expériences de connexion et identifier les besoins de vos
-      auditoires
-    li_3: Mener des recherches avant de bâtir ou de mettre en œuvre un système
-    li_4: Tester votre produit pour identifier les points morts ou les domaines qui
-      nécessitent une amélioration
-    li_5: Lorsque les meilleures pratiques actuelles ne sont pas assez bonnes pour
-      vos utilisateurs, testez de nouvelles solutions et aidez à guider
-      l’adoption.
-  ul_2:
-    li_1: Impliquez des experts, des intervenants et le public tôt et souvent
-    li_2: Expliquez comment et pourquoi vous recueillez, partagez et stockez des
-      données
-    li_3: Créez une politique de confidentialité à laquelle tous peuvent accéder et
-      que tous peuvent comprendre
-    li_4: Créez une politique de confidentialité inclusive et informative
-  ul_3:
-    li_1: Développer le produit en sprints et évaluer son efficacité après chaque
-      sprint
-    li_2: Communiquer continuellement avec les parties prenantes et les experts afin
-      d’évaluer les besoins et les mesures de succès
-    li_3: Tester votre produit auprès des utilisateurs de façon continuelle au fur
-      et à mesure que vous ajoutez de nouvelles fonctionnalités et raffinez les
-      fonctionnalités existantes
-    li_4: Définir ce qu’un produit minimal viable est pour vos besoins de gestion
-      d’identité
-    li_5: Planifier une évolution basée sur une technologie et des normes changeantes
-  ul_4:
-    li_1: Stockez aussi peu de renseignements permettant d’identifier une personne
-      que possible
-    li_2: Donnez au utilisateurs les moyens d’atteindre leurs objectifs
-    li_3: Donnez aux utilisateurs le contrôle de leurs données
-  ul_5:
-    li_1: Identifier les meilleures pratiques de l’industrie et s’y conformer
-    li_2: Se conformer aux règlementations fédérales comme FISMA et FedRamp
-    li_3: Mettre en place des systèmes pour effectuer une surveillance et une
-      détection de la fraude
-    li_4: Utiliser des techniques modernes de chiffrement dans toute la pile
-      technologique
-    li_5: Stocker seulement la quantité minimale nécessaire de données
-    li_6: Aider les utilisateurs à comprendre les mesures de sécurité qu’ils doivent
-      effectuer

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -3,11 +3,16 @@ require 'spec_helper'
 
 RSpec.describe 'data' do
   it 'has the same keys across all locales' do
-    keys = Dir['_data/*/settings.yml'].map { |path| hash_keys(YAML.load_file(path)) }
+    keys = Dir['_data/*/settings.yml'].map { |path| [path, hash_keys(YAML.load_file(path))] }
 
-    expect(keys).not_to be_empty
-    keys.combination(2).each do |first, second|
-      expect(first).to match_array(second)
+    first_file_keys, *other_file_keys = keys
+    first_file, first_keys = first_file_keys
+    aggregate_failures do
+      other_file_keys.each do |other_file, other_keys|
+        expect(first_keys).to match_array(other_keys),
+                              "Expected `#{other_file}` to contain same keys as `#{first_file}`\n" \
+                              "Difference: #{first_keys - other_keys | other_keys - first_keys}"
+      end
     end
   end
 

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -1,0 +1,26 @@
+require 'yaml'
+require 'spec_helper'
+require 'pry'
+
+RSpec.describe 'data' do
+  it 'has the same keys across all locales' do
+    keys = Dir['_data/*/settings.yml'].map { |path| hash_keys(YAML.load_file(path)) }
+
+    expect(keys).not_to be_empty
+    keys.combination(2).each do |first, second|
+      expect(first).to match_array(second)
+    end
+  end
+
+  def hash_keys(hash, parent_keys: [], all_keys: [])
+    hash.each do |key, value|
+      if value.is_a?(Hash)
+        hash_keys(value, parent_keys: parent_keys + [key], all_keys:)
+      else
+        all_keys << [*parent_keys, key].join('.')
+      end
+    end
+
+    all_keys
+  end
+end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -1,6 +1,5 @@
 require 'yaml'
 require 'spec_helper'
-require 'pry'
 
 RSpec.describe 'data' do
   it 'has the same keys across all locales' do


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused values from `settings.yml` files within `_data`, and adds a test case to ensure that keys are consistent between all languages.

Related comment: https://github.com/GSA-TTS/identity-site/pull/1226#discussion_r1541338931

Identifying lack of use required some manual effort, specifically searching `settings.[key]`

## 📜 Testing Plan

```
bundle exec rspec spec/data_spec.rb
```

Verify no lingering references in code to removed keys.