### PR TITLE
Fix visual bug, icons scrolling in front of sticky header

### DIFF
--- a/_sass/components/_sticky-table.scss
+++ b/_sass/components/_sticky-table.scss
@@ -9,6 +9,7 @@
     background-color: color('white');
     position: sticky;
     top: 0;
+    z-index: 1;
 
     &::after {
       content: '';


### PR DESCRIPTION
Noticed a small visual bug on the [International Phone Support page](https://login.gov/help/manage-your-account/international-phone-support/), made a quick attempt to fix it

| before | after |
| --- | --- |
| <img width="645" alt="Screenshot 2024-04-29 at 8 45 27 AM" src="https://github.com/GSA-TTS/identity-site/assets/458784/40fc5cc2-527b-425c-ac2a-8a7ff7d9af30"> | <img width="645" alt="Screenshot 2024-04-29 at 8 45 31 AM" src="https://github.com/GSA-TTS/identity-site/assets/458784/ecb575b6-69ee-4d7b-8da2-cebae2273ae6"> |


