### PR TITLE
Remove titles from links

### DIFF
--- a/content/_policy/contact._en.md
+++ b/content/_policy/contact._en.md
@@ -36,7 +36,7 @@ partner_content: >-
 report_issue_content: >-
   ## Report an issue
 
-  If you want to report an issue, please review our vulnerability disclosure policy [vulnerability disclosure policy](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/responding-to-public-disclosure-vulnerabilities/ "Follow link") and contact us using our [vulnerability disclosure form](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform "Follow link").
+  If you want to report an issue, please review our vulnerability disclosure policy [vulnerability disclosure policy](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/responding-to-public-disclosure-vulnerabilities/) and contact us using our [vulnerability disclosure form](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
 scripts:
   - /assets/js/contact.js
 permalink: /contact/

--- a/content/_policy/contact._es.md
+++ b/content/_policy/contact._es.md
@@ -36,7 +36,7 @@ partner_content: >-
 report_issue_content: >-
   ## Informe de un problema
 
-  Si desea informar de un problema, consulte nuestra [política de divulgación de vulnerabilidades](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/responding-to-public-disclosure-vulnerabilities/ "Vínculo de seguimiento") y contáctenos usando nuestro [formulario de divulgación de vulnerabilidades](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform "Vínculo de seguimiento").
+  Si desea informar de un problema, consulte nuestra [política de divulgación de vulnerabilidades](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/responding-to-public-disclosure-vulnerabilities/) y contáctenos usando nuestro [formulario de divulgación de vulnerabilidades](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
 
 scripts:
   - /assets/js/contact.js


### PR DESCRIPTION
## 🛠 Summary of changes

Based on discussion [here](https://github.com/GSA-TTS/identity-site/pull/1240#discussion_r1591262509), this PR removes the `"title"` attribute from the links. For accessibility purposes, [W3C](https://www.w3.org/TR/WCAG20-TECHS/H33.html) says:

> For each anchor element that has a title attribute, check that the title attribute together with the link text describes the purpose of the link.

The titles in this case are instructions to follow the link, which do not describe the purpose of the link.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
|  |  |
-->

