### PR TITLE
Add missing normalize-yaml to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,11 @@ lint-assets:
 	npm run optimize-assets > /dev/null
 	git diff --quiet assets/img || (echo "Error: Optimize SVG images using 'npm run optimize-assets'"; exit 1)
 
-lint-yaml:
+lint-yaml: normalize-yaml
+	(! git diff --name-only | grep ".*\.yml$$") || (echo "Error: Run 'make normalize-yaml' to normalize YAML"; exit 1)
+
+normalize-yaml: # Normalizes YAML files (alphabetizes keys, fixes line length, smart quotes)
 	npm run normalize-yaml
-	(! git diff --name-only | grep ".*\.yml$$") || (echo "Error: Run 'make normalize_yaml' to normalize YAML"; exit 1)
 
 lint-css:
 	npm run lint:css


### PR DESCRIPTION
## 🛠 Summary of changes

We currently have a `lint-yaml` task in the Makefile that outputs `Error: Run 'make normalize_yaml' to normalize YAML` if the lint fails, but we haven't defined that yet. This PR implements the `normalize-yaml` task and makes use of it in `lint-yaml`  like we do in the IDP: https://github.com/18F/identity-idp/blob/5b1b15e/Makefile#L110-L111
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
|  |  |
-->

