### PR TITLE
Override GSA-TTS .allstar config for "dismiss stale reviews"

### DIFF
--- a/.allstar/branch_protection.yaml
+++ b/.allstar/branch_protection.yaml
@@ -1,0 +1,1 @@
+dismissStale: false


### PR DESCRIPTION
**Why**: We believe this still meets the AC-2 control, while also allowing for a more flexible workflow for Login.gov contributors

See https://github.com/GSA-TTS/identity-handbook/pull/560. After this is approved and merged, I can remove the "dismiss stale reviews" checkbox in settings.