### PR TITLE
Remove dead CBP links

### DIFF
--- a/content/_help/specific-agencies/trusted-traveler-programs._en.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._en.md
@@ -38,13 +38,8 @@ Login.gov can only answer questions about the sign-in process and creating a Log
 
 Please contact the [Trusted Traveler Programs](https://help.cbp.gov/s/questions?language=en_US) directly if you have questions regarding:
 
-* Applications
-  * [Application status](https://help.cbp.gov/s/article/Article-1886?language=en_US)
-  * [Application changes](https://help.cbp.gov/s/article/Article-1377?language=en_US)
-* Appointments
-  * [Scheduling or changing appointments](https://help.cbp.gov/s/article/Article-1378?language=en_US)
-  * [Enrollment on Arrival](https://help.cbp.gov/s/article/Article-1871?language=en_US)
-* [Lost, stolen, or damaged NEXUS, SENTRI, or Global Entry card](https://help.cbp.gov/s/article/Article-1206?language=en_US)
+* [Application status](https://help.cbp.gov/s/article/Article-1886?language=en_US)
+* [Enrollment on Arrival](https://help.cbp.gov/s/article/Article-1871?language=en_US)
 * [Applied for wrong Trusted Traveler Program](https://help.cbp.gov/s/article/Article-1759?language=en_US)
 * [Other Trusted Traveler Program questions](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 

--- a/content/_help/specific-agencies/trusted-traveler-programs._es.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._es.md
@@ -35,13 +35,9 @@ Login.gov solo puede responder las preguntas sobre el proceso de inicio de sesi�
 
 Contacte directamente con los [programas para viajeros de confianza](https://help.cbp.gov/s/questions?language=es) si tiene preguntas acerca de:
 
-* Solicitudes
-  * [Estado de la solicitud](https://help.cbp.gov/s/article/Article-1886?language=es)
-  * [Cambios en la solicitud](https://help.cbp.gov/s/article/Article-1377?language=es)
-* Citas
-  * [Programación o cambio de citas](https://help.cbp.gov/s/article/Article-1378?language=es)
-  * [Inscripción al llegar](https://help.cbp.gov/s/article/Article-1871?language=es)
-* [Tarjeta de NEXUS, SENTRI o Global Entry extraviada, robada o dañada](https://help.cbp.gov/s/article/Article-1206?language=es)
+
+* [Estado de la solicitud](https://help.cbp.gov/s/article/Article-1886?language=es)
+* [Inscripción al llegar](https://help.cbp.gov/s/article/Article-1871?language=es)
 * [Solicitud para el programa para viajeros de confianza equivocado](https://help.cbp.gov/s/article/Article-1759?language=es)
 * [Otras preguntas sobre el programa para viajeros de confianza](https://help.cbp.gov/s/all-ttp-articles?language=es)
 

--- a/content/_help/specific-agencies/trusted-traveler-programs._fr.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._fr.md
@@ -35,9 +35,7 @@ Login.gov ne peut répondre qu'aux questions concernant la création d'un compte
 
 Veuillez contacter directement les [Programmes voyageurs sans risque](https://help.cbp.gov/s/questions?language=en_US) si vous avez des questions concernant:
 
-
 * [État de la demande](https://help.cbp.gov/s/article/Article-1886?language=en_US)
-
 * [Inscription à l’arrivée](https://help.cbp.gov/s/article/Article-1871?language=en_US)
 * [Demande déposée pour le mauvais Programme pour voyageurs fiables](https://help.cbp.gov/s/article/Article-1759?language=en_US)
 * [Autres questions au sujet du Programme pour voyageurs fiables](https://help.cbp.gov/s/all-ttp-articles?language=en_US)

--- a/content/_help/specific-agencies/trusted-traveler-programs._fr.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._fr.md
@@ -35,13 +35,10 @@ Login.gov ne peut répondre qu'aux questions concernant la création d'un compte
 
 Veuillez contacter directement les [Programmes voyageurs sans risque](https://help.cbp.gov/s/questions?language=en_US) si vous avez des questions concernant:
 
-* Demandes
-  * [État de la demande](https://help.cbp.gov/s/article/Article-1886?language=en_US)
-  * [Modifications de la demande](https://help.cbp.gov/s/article/Article-1377?language=en_US)
-* Rendez-vous
-  * [Prendre ou modifier un rendez-vous](https://help.cbp.gov/s/article/Article-1378?language=en_US)
-  * [Inscription à l’arrivée](https://help.cbp.gov/s/article/Article-1871?language=en_US)
-* [Carte NEXUS, SENTRI ou Global Entry perdue, volée ou endommagée](https://help.cbp.gov/s/article/Article-1206?language=en_US)
+
+* [État de la demande](https://help.cbp.gov/s/article/Article-1886?language=en_US)
+
+* [Inscription à l’arrivée](https://help.cbp.gov/s/article/Article-1871?language=en_US)
 * [Demande déposée pour le mauvais Programme pour voyageurs fiables](https://help.cbp.gov/s/article/Article-1759?language=en_US)
 * [Autres questions au sujet du Programme pour voyageurs fiables](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 

--- a/content/_help/specific-agencies/trusted-traveler-programs._zh.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._zh.md
@@ -13,13 +13,8 @@ Login.gov 只能回答有关登录过程和设立 Login.gov 账户的问题。
 
 如果你有事关以下内容的问题，请直接联系[受信任旅客计划](https://help.cbp.gov/s/questions?language=en_US)：
 
-* 申请
-  * [申请状态](https://help.cbp.gov/s/article/Article-1886?language=en_US)
-  * [申请变更](https://help.cbp.gov/s/article/Article-1377?language=en_US)
-* 预约
-  * [安排或变更预约时间](https://help.cbp.gov/s/article/Article-1378?language=en_US)
-  * [到达时注册](https://help.cbp.gov/s/article/Article-1871?language=en_US)
-* [NEXUS、SENTRI或全球入境（Global Entry）卡丢失、被盗或受损](https://help.cbp.gov/s/article/Article-1206?language=en_US)
+* [申请状态](https://help.cbp.gov/s/article/Article-1886?language=en_US)
+* [到达时注册](https://help.cbp.gov/s/article/Article-1871?language=en_US)
 * [申请的受信任旅客计划不对](https://help.cbp.gov/s/article/Article-1759?language=en_US)
 * [其他有关受信任旅客计划的问题](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 


### PR DESCRIPTION
This PR removes articles that are causing failures in the `external-link-check` pipeline.