### PR TITLE
Remove 'Applied for wrong Trusted Traveler Program' link due to 404

### DIFF
--- a/content/_help/specific-agencies/trusted-traveler-programs._en.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._en.md
@@ -40,7 +40,6 @@ Please contact the [Trusted Traveler Programs](https://help.cbp.gov/s/questions?
 
 * [Application status](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * [Enrollment on Arrival](https://help.cbp.gov/s/article/Article-1871?language=en_US)
-* [Applied for wrong Trusted Traveler Program](https://help.cbp.gov/s/article/Article-1759?language=en_US)
 * [Other Trusted Traveler Program questions](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 
 Important notes:

--- a/content/_help/specific-agencies/trusted-traveler-programs._es.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._es.md
@@ -38,7 +38,6 @@ Contacte directamente con los [programas para viajeros de confianza](https://hel
 
 * [Estado de la solicitud](https://help.cbp.gov/s/article/Article-1886?language=es)
 * [Inscripción al llegar](https://help.cbp.gov/s/article/Article-1871?language=es)
-* [Solicitud para el programa para viajeros de confianza equivocado](https://help.cbp.gov/s/article/Article-1759?language=es)
 * [Otras preguntas sobre el programa para viajeros de confianza](https://help.cbp.gov/s/all-ttp-articles?language=es)
 
 Información importante:

--- a/content/_help/specific-agencies/trusted-traveler-programs._fr.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._fr.md
@@ -37,7 +37,6 @@ Veuillez contacter directement les [Programmes voyageurs sans risque](https://he
 
 * [État de la demande](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * [Inscription à l’arrivée](https://help.cbp.gov/s/article/Article-1871?language=en_US)
-* [Demande déposée pour le mauvais Programme pour voyageurs fiables](https://help.cbp.gov/s/article/Article-1759?language=en_US)
 * [Autres questions au sujet du Programme pour voyageurs fiables](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 
 Notes importantes :

--- a/content/_help/specific-agencies/trusted-traveler-programs._zh.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._zh.md
@@ -15,7 +15,6 @@ Login.gov 只能回答有关登录过程和设立 Login.gov 账户的问题。
 
 * [申请状态](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * [到达时注册](https://help.cbp.gov/s/article/Article-1871?language=en_US)
-* [申请的受信任旅客计划不对](https://help.cbp.gov/s/article/Article-1759?language=en_US)
 * [其他有关受信任旅客计划的问题](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 
 注意要点：


### PR DESCRIPTION
This PR is a hotfix that addresses a [failed external link check](https://gsa-tts.slack.com/archives/C0NGESUN5/p1718885283770509).

CBP removed the their help center link for "Applied to wrong Trusted Traveler Program". This link will be deleted. 