### PR TITLE
Use hreflang for language picker, spec exception

### DIFF
--- a/_includes/language_picker.html
+++ b/_includes/language_picker.html
@@ -26,7 +26,7 @@
   >
     {% for locale in site.languages %}
       <li>
-        <a href="{{ page.url | delocalize_url | locale_url: locale }}" lang="{{ locale }}">
+        <a href="{{ page.url | delocalize_url | locale_url: locale }}" lang="{{ locale }}" hreflang="{{ locale }}">
           {{ site.data.[locale].settings.global.locales[locale] }}
         </a>
       </li>

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -39,7 +39,9 @@ RSpec::Matchers.define :link_to_locale_pages do |locale|
     doc = actual
 
     doc.css("a[href^='/'],a[href^='#{SITE_URL}']").each do |a|
-      next if a[:lang]
+      # `hreflang` implies that it's intentional for the link target language to differ from the
+      # current page language.
+      next if a[:hreflang]
       page = a[:href]
       link_path = URI::parse(page).path
       next if link_path.start_with?('/partners/')


### PR DESCRIPTION
## 🛠 Summary of changes

Updates language picker to render links with a `hreflang` attribute.

Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#hreflang

**Why?**

- As documented, this creates a hint at the target language of the linked resource, which could be used by the browser or a search engine
- It's more meaningful for the exception that was added to spec verifying language links matching the page language

Previous discussion: https://github.com/GSA-TTS/identity-site/pull/1286#discussion_r1657498153

## 📜 Testing Plan

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/aduth-hreflang/
2. Inspect links in language picker
3. Observe `hreflang` attribute matches locale of the target link