### PR TITLE
Update zh settings.yml

### DIFF
--- a/_data/zh/settings.yml
+++ b/_data/zh/settings.yml
@@ -192,7 +192,7 @@ feedback_form:
   question: '这篇文章对你有帮助吗？'
   'yes': 对
 global:
-  language: 中文 (简体)
+  language: 语言
   locales:
     en: English
     es: Español


### PR DESCRIPTION
## 🛠 Summary of changes

Update language picker on the brochure site to say `语言` instead of `中文 (简体)` when `中文 (简体)` is selected.