### PR TITLE
Fix broken Markdown links for French content

### DIFF
--- a/content/_help/trouble-signing-in/issues-with-authentication-methods._fr.md
+++ b/content/_help/trouble-signing-in/issues-with-authentication-methods._fr.md
@@ -55,7 +55,7 @@ Seul le dernier code à usage unique que vous recevrez fonctionnera. Si vous dem
 
 * Il se peut que l’heure ne soit pas correctement synchronisée entre votre appareil et votre appli d’authentification. Assurez-vous que l’heure de votre appareil est correcte en utilisant une page comme [time.gov](https://www.time.gov/).
 
-  * Si vous utilisez Google Authenticator, il vous faudra peut-être synchroniser l’heure manuellement. [Suivez les [instructions de Google pour synchroniser votre heure.](https://support.google.com/accounts/answer/185834?hl=en)](https://support.google.com/accounts/answer/185834?hl=en)
+  * Si vous utilisez Google Authenticator, il vous faudra peut-être synchroniser l’heure manuellement. [Suivez les instructions de Google pour synchroniser votre heure.](https://support.google.com/accounts/answer/185834?hl=en)
 
 ## Mon code de sauvegarde ne fonctionne pas
 

--- a/content/_policy/accessibility._fr.md
+++ b/content/_policy/accessibility._fr.md
@@ -24,8 +24,8 @@ Nos rapports d’évaluation de l’accessibilité passés sont disponibles ci-d
 
 * Télécharger le [Rapport d’authentification [DOCX, 150KB]](/docs/2024-05-15_VPAT2.5Rev508-Identity-Authentication.docx)
 * [Rapport d’authentification [PDF, 138KB]](/docs/2024-05-15_VPAT2.5Rev508-Identity-Authentication.pdf)
-* Télécharger le [Rapport sur la vérification d'identité \[DOCX, 363KB]](/docs/identity-verification-report.docx)
-* [Rapport sur la vérification d'identité \[PDF, 150KB]](/docs/identity-verification-report.pdf)
+* Télécharger le [Rapport sur la vérification d'identité [DOCX, 363KB]](/docs/identity-verification-report.docx)
+* [Rapport sur la vérification d'identité [PDF, 150KB]](/docs/identity-verification-report.pdf)
 
 ## Limites connues
 Vous trouverez ci-dessous une description des types de limites en matière d’accessibilité que nos évaluations ont permis de mettre en lumière.

--- a/spec/all_pages_spec.rb
+++ b/spec/all_pages_spec.rb
@@ -45,7 +45,9 @@ RSpec.describe 'all pages' do
       end
 
       it 'does not have broken Markdown links' do
-        expect(doc.to_s).to_not include(')]')
+        html = doc.to_s
+        expect(html).to_not include(')]')
+        expect(html).to_not match(/\]\((http|\/)/)
       end
 
       it 'does not link to a placeholder redirect_from page' do


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a couple instances of invalid Markdown producing pages with lingering Markdown formatting.

## 📜 Testing Plan

Review the following pages and verify no broken Markdown:

- https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/aduth-broken-markdown-links/fr/help/trouble-signing-in/issues-with-authentication-methods/
- https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/aduth-broken-markdown-links/fr/accessibility/

## 📸 Screenshots

Page|Before|After
---|---|---
Issues with authentication methods|![image](https://github.com/user-attachments/assets/ff34e824-fc12-4def-ac8c-386d744b3934)|![image](https://github.com/user-attachments/assets/c267e84a-188a-40b7-9663-f95a0eb4f4d8)
Accessibility|![image](https://github.com/user-attachments/assets/0007c9a9-b044-4605-964f-c7affb2d67c2)|![image](https://github.com/user-attachments/assets/32469e78-8e52-475e-a69e-921b2618cfef)
