### PR TITLE
Remove broken link to TTP Application Status article

### DIFF
--- a/content/_help/specific-agencies/trusted-traveler-programs._en.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._en.md
@@ -38,7 +38,6 @@ Login.gov can only answer questions about the sign-in process and creating a Log
 
 Please contact the [Trusted Traveler Programs](https://help.cbp.gov/s/questions?language=en_US) directly if you have questions regarding:
 
-* [Application status](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * [Enrollment on Arrival](https://help.cbp.gov/s/article/Article-1871?language=en_US)
 * [Other Trusted Traveler Program questions](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 

--- a/content/_help/specific-agencies/trusted-traveler-programs._es.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._es.md
@@ -35,8 +35,6 @@ Login.gov solo puede responder las preguntas sobre el proceso de inicio de sesi√
 
 Contacte directamente con los [programas para viajeros de confianza](https://help.cbp.gov/s/questions?language=es) si tiene preguntas acerca de:
 
-
-* [Estado de la solicitud](https://help.cbp.gov/s/article/Article-1886?language=es)
 * [Inscripci√≥n al llegar](https://help.cbp.gov/s/article/Article-1871?language=es)
 * [Otras preguntas sobre el programa para viajeros de confianza](https://help.cbp.gov/s/all-ttp-articles?language=es)
 

--- a/content/_help/specific-agencies/trusted-traveler-programs._fr.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._fr.md
@@ -35,7 +35,6 @@ Login.gov ne peut répondre qu'aux questions concernant la création d'un compte
 
 Veuillez contacter directement les [Programmes voyageurs sans risque](https://help.cbp.gov/s/questions?language=en_US) si vous avez des questions concernant:
 
-* [État de la demande](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * [Inscription à l’arrivée](https://help.cbp.gov/s/article/Article-1871?language=en_US)
 * [Autres questions au sujet du Programme pour voyageurs fiables](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 

--- a/content/_help/specific-agencies/trusted-traveler-programs._zh.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._zh.md
@@ -13,7 +13,6 @@ Login.gov 只能回答有关登录过程和设立 Login.gov 账户的问题。
 
 如果你有事关以下内容的问题，请直接联系[受信任旅客计划](https://help.cbp.gov/s/questions?language=en_US)：
 
-* [申请状态](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * [到达时注册](https://help.cbp.gov/s/article/Article-1871?language=en_US)
 * [其他有关受信任旅客计划的问题](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a broken link to TTP help article for "Application Status".

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1721390880566609

## 📜 Testing Plan

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/aduth-rm-ttp-app-status/help/specific-agencies/trusted-traveler-programs/
2. Verify that all links under "Please contact the Trusted Traveler Programs directly if you have questions regarding:" go to a valid article on the DHS website