### PR TITLE
Restore links to Trusted Traveler Program help article

### DIFF
--- a/content/_help/specific-agencies/trusted-traveler-programs._en.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._en.md
@@ -38,7 +38,14 @@ Login.gov can only answer questions about the sign-in process and creating a Log
 
 Please contact the [Trusted Traveler Programs](https://help.cbp.gov/s/questions?language=en_US) directly if you have questions regarding:
 
-* [Enrollment on Arrival](https://help.cbp.gov/s/article/Article-1871?language=en_US)
+* Applications
+  * [Application status](https://help.cbp.gov/s/article/Article-1886?language=en_US)
+  * [Application changes](https://help.cbp.gov/s/article/Article-1377?language=en_US)
+* Appointments
+  * [Scheduling or changing appointments](https://help.cbp.gov/s/article/Article-1378?language=en_US)
+  * [Enrollment on Arrival](https://help.cbp.gov/s/article/Article-1871?language=en_US)
+* [Lost, stolen, or damaged NEXUS, SENTRI, or Global Entry card](https://help.cbp.gov/s/article/Article-1206?language=en_US)
+* [Applied for wrong Trusted Traveler Program](https://help.cbp.gov/s/article/Article-1759?language=en_US)
 * [Other Trusted Traveler Program questions](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 
 Important notes:

--- a/content/_help/specific-agencies/trusted-traveler-programs._en.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._en.md
@@ -40,10 +40,10 @@ Please contact the [Trusted Traveler Programs](https://help.cbp.gov/s/questions?
 
 * [Application status](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * Appointments
-  * [Scheduling or changing appointments](https://help.cbp.gov/s/article/Article-1378?language=en_US)
+  * [Scheduling or changing appointments](https://help.cbp.gov/s/article/Article1850?language=en_US)
   * [Enrollment on Arrival](https://help.cbp.gov/s/article/Article-1871?language=en_US)
-* [Lost, stolen, or damaged NEXUS, SENTRI, or Global Entry card](https://help.cbp.gov/s/article/Article-1206?language=en_US)
-* [Applied for wrong Trusted Traveler Program](https://help.cbp.gov/s/article/Article-1759?language=en_US)
+* [Lost, stolen, or damaged NEXUS, SENTRI, or Global Entry card](https://help.cbp.gov/s/article/Article-1453?language=en_US)
+* [Applied for wrong Trusted Traveler Program](https://help.cbp.gov/s/article/Article-1354?language=en_US)
 * [Other Trusted Traveler Program questions](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 
 Important notes:

--- a/content/_help/specific-agencies/trusted-traveler-programs._en.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._en.md
@@ -38,9 +38,7 @@ Login.gov can only answer questions about the sign-in process and creating a Log
 
 Please contact the [Trusted Traveler Programs](https://help.cbp.gov/s/questions?language=en_US) directly if you have questions regarding:
 
-* Applications
-  * [Application status](https://help.cbp.gov/s/article/Article-1886?language=en_US)
-  * [Application changes](https://help.cbp.gov/s/article/Article-1377?language=en_US)
+* [Application status](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * Appointments
   * [Scheduling or changing appointments](https://help.cbp.gov/s/article/Article-1378?language=en_US)
   * [Enrollment on Arrival](https://help.cbp.gov/s/article/Article-1871?language=en_US)

--- a/content/_help/specific-agencies/trusted-traveler-programs._es.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._es.md
@@ -37,10 +37,10 @@ Contacte directamente con los [programas para viajeros de confianza](https://hel
 
 * [Estado de la solicitud](https://help.cbp.gov/s/article/Article-1886?language=es)
 * Citas
-  * [Programación o cambio de citas](https://help.cbp.gov/s/article/Article-1378?language=es)
+  * [Programación o cambio de citas](https://help.cbp.gov/s/article/Article1850?language=es)
   * [Inscripción al llegar](https://help.cbp.gov/s/article/Article-1871?language=es)
-* [Tarjeta de NEXUS, SENTRI o Global Entry extraviada, robada o dañada](https://help.cbp.gov/s/article/Article-1206?language=es)
-* [Solicitud para el programa para viajeros de confianza equivocado](https://help.cbp.gov/s/article/Article-1759?language=es)
+* [Tarjeta de NEXUS, SENTRI o Global Entry extraviada, robada o dañada](https://help.cbp.gov/s/article/Article-1453?language=es)
+* [Solicitud para el programa para viajeros de confianza equivocado](https://help.cbp.gov/s/article/Article-1354?language=es)
 * [Otras preguntas sobre el programa para viajeros de confianza](https://help.cbp.gov/s/all-ttp-articles?language=es)
 
 Información importante:

--- a/content/_help/specific-agencies/trusted-traveler-programs._es.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._es.md
@@ -35,9 +35,7 @@ Login.gov solo puede responder las preguntas sobre el proceso de inicio de sesi�
 
 Contacte directamente con los [programas para viajeros de confianza](https://help.cbp.gov/s/questions?language=es) si tiene preguntas acerca de:
 
-* Solicitudes
-  * [Estado de la solicitud](https://help.cbp.gov/s/article/Article-1886?language=es)
-  * [Cambios en la solicitud](https://help.cbp.gov/s/article/Article-1377?language=es)
+* [Estado de la solicitud](https://help.cbp.gov/s/article/Article-1886?language=es)
 * Citas
   * [Programación o cambio de citas](https://help.cbp.gov/s/article/Article-1378?language=es)
   * [Inscripción al llegar](https://help.cbp.gov/s/article/Article-1871?language=es)

--- a/content/_help/specific-agencies/trusted-traveler-programs._es.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._es.md
@@ -35,7 +35,14 @@ Login.gov solo puede responder las preguntas sobre el proceso de inicio de sesi�
 
 Contacte directamente con los [programas para viajeros de confianza](https://help.cbp.gov/s/questions?language=es) si tiene preguntas acerca de:
 
-* [Inscripción al llegar](https://help.cbp.gov/s/article/Article-1871?language=es)
+* Solicitudes
+  * [Estado de la solicitud](https://help.cbp.gov/s/article/Article-1886?language=es)
+  * [Cambios en la solicitud](https://help.cbp.gov/s/article/Article-1377?language=es)
+* Citas
+  * [Programación o cambio de citas](https://help.cbp.gov/s/article/Article-1378?language=es)
+  * [Inscripción al llegar](https://help.cbp.gov/s/article/Article-1871?language=es)
+* [Tarjeta de NEXUS, SENTRI o Global Entry extraviada, robada o dañada](https://help.cbp.gov/s/article/Article-1206?language=es)
+* [Solicitud para el programa para viajeros de confianza equivocado](https://help.cbp.gov/s/article/Article-1759?language=es)
 * [Otras preguntas sobre el programa para viajeros de confianza](https://help.cbp.gov/s/all-ttp-articles?language=es)
 
 Información importante:

--- a/content/_help/specific-agencies/trusted-traveler-programs._fr.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._fr.md
@@ -35,7 +35,14 @@ Login.gov ne peut répondre qu'aux questions concernant la création d'un compte
 
 Veuillez contacter directement les [Programmes voyageurs sans risque](https://help.cbp.gov/s/questions?language=en_US) si vous avez des questions concernant:
 
-* [Inscription à l’arrivée](https://help.cbp.gov/s/article/Article-1871?language=en_US)
+* Demandes
+  * [État de la demande](https://help.cbp.gov/s/article/Article-1886?language=en_US)
+  * [Modifications de la demande](https://help.cbp.gov/s/article/Article-1377?language=en_US)
+* Rendez-vous
+  * [Prendre ou modifier un rendez-vous](https://help.cbp.gov/s/article/Article-1378?language=en_US)
+  * [Inscription à l’arrivée](https://help.cbp.gov/s/article/Article-1871?language=en_US)
+* [Carte NEXUS, SENTRI ou Global Entry perdue, volée ou endommagée](https://help.cbp.gov/s/article/Article-1206?language=en_US)
+* [Demande déposée pour le mauvais Programme pour voyageurs fiables](https://help.cbp.gov/s/article/Article-1759?language=en_US)
 * [Autres questions au sujet du Programme pour voyageurs fiables](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 
 Notes importantes :

--- a/content/_help/specific-agencies/trusted-traveler-programs._fr.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._fr.md
@@ -37,10 +37,10 @@ Veuillez contacter directement les [Programmes voyageurs sans risque](https://he
 
 * [État de la demande](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * Rendez-vous
-  * [Prendre ou modifier un rendez-vous](https://help.cbp.gov/s/article/Article-1378?language=en_US)
+  * [Prendre ou modifier un rendez-vous](https://help.cbp.gov/s/article/Article1850?language=en_US)
   * [Inscription à l’arrivée](https://help.cbp.gov/s/article/Article-1871?language=en_US)
-* [Carte NEXUS, SENTRI ou Global Entry perdue, volée ou endommagée](https://help.cbp.gov/s/article/Article-1206?language=en_US)
-* [Demande déposée pour le mauvais Programme pour voyageurs fiables](https://help.cbp.gov/s/article/Article-1759?language=en_US)
+* [Carte NEXUS, SENTRI ou Global Entry perdue, volée ou endommagée](https://help.cbp.gov/s/article/Article-1453?language=en_US)
+* [Demande déposée pour le mauvais Programme pour voyageurs fiables](https://help.cbp.gov/s/article/Article-1354?language=en_US)
 * [Autres questions au sujet du Programme pour voyageurs fiables](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 
 Notes importantes :

--- a/content/_help/specific-agencies/trusted-traveler-programs._fr.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._fr.md
@@ -35,9 +35,7 @@ Login.gov ne peut répondre qu'aux questions concernant la création d'un compte
 
 Veuillez contacter directement les [Programmes voyageurs sans risque](https://help.cbp.gov/s/questions?language=en_US) si vous avez des questions concernant:
 
-* Demandes
-  * [État de la demande](https://help.cbp.gov/s/article/Article-1886?language=en_US)
-  * [Modifications de la demande](https://help.cbp.gov/s/article/Article-1377?language=en_US)
+* [État de la demande](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * Rendez-vous
   * [Prendre ou modifier un rendez-vous](https://help.cbp.gov/s/article/Article-1378?language=en_US)
   * [Inscription à l’arrivée](https://help.cbp.gov/s/article/Article-1871?language=en_US)

--- a/content/_help/specific-agencies/trusted-traveler-programs._zh.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._zh.md
@@ -15,10 +15,10 @@ Login.gov 只能回答有关登录过程和设立 Login.gov 账户的问题。
 
 * [申请状态](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * 预约
-  * [安排或变更预约时间](https://help.cbp.gov/s/article/Article-1378?language=en_US)
+  * [安排或变更预约时间](https://help.cbp.gov/s/article/Article1850?language=en_US)
   * [到达时注册](https://help.cbp.gov/s/article/Article-1871?language=en_US)
-* [NEXUS、SENTRI或全球入境（Global Entry）卡丢失、被盗或受损](https://help.cbp.gov/s/article/Article-1206?language=en_US)
-* [申请的受信任旅客计划不对](https://help.cbp.gov/s/article/Article-1759?language=en_US)
+* [NEXUS、SENTRI或全球入境（Global Entry）卡丢失、被盗或受损](https://help.cbp.gov/s/article/Article-1453?language=en_US)
+* [申请的受信任旅客计划不对](https://help.cbp.gov/s/article/Article-1354?language=en_US)
 * [其他有关受信任旅客计划的问题](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 
 注意要点：

--- a/content/_help/specific-agencies/trusted-traveler-programs._zh.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._zh.md
@@ -13,7 +13,14 @@ Login.gov 只能回答有关登录过程和设立 Login.gov 账户的问题。
 
 如果你有事关以下内容的问题，请直接联系[受信任旅客计划](https://help.cbp.gov/s/questions?language=en_US)：
 
-* [到达时注册](https://help.cbp.gov/s/article/Article-1871?language=en_US)
+* 申请
+  * [申请状态](https://help.cbp.gov/s/article/Article-1886?language=en_US)
+  * [申请变更](https://help.cbp.gov/s/article/Article-1377?language=en_US)
+* 预约
+  * [安排或变更预约时间](https://help.cbp.gov/s/article/Article-1378?language=en_US)
+  * [到达时注册](https://help.cbp.gov/s/article/Article-1871?language=en_US)
+* [NEXUS、SENTRI或全球入境（Global Entry）卡丢失、被盗或受损](https://help.cbp.gov/s/article/Article-1206?language=en_US)
+* [申请的受信任旅客计划不对](https://help.cbp.gov/s/article/Article-1759?language=en_US)
 * [其他有关受信任旅客计划的问题](https://help.cbp.gov/s/all-ttp-articles?language=en_US)
 
 注意要点：

--- a/content/_help/specific-agencies/trusted-traveler-programs._zh.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._zh.md
@@ -13,9 +13,7 @@ Login.gov 只能回答有关登录过程和设立 Login.gov 账户的问题。
 
 如果你有事关以下内容的问题，请直接联系[受信任旅客计划](https://help.cbp.gov/s/questions?language=en_US)：
 
-* 申请
-  * [申请状态](https://help.cbp.gov/s/article/Article-1886?language=en_US)
-  * [申请变更](https://help.cbp.gov/s/article/Article-1377?language=en_US)
+* [申请状态](https://help.cbp.gov/s/article/Article-1886?language=en_US)
 * 预约
   * [安排或变更预约时间](https://help.cbp.gov/s/article/Article-1378?language=en_US)
   * [到达时注册](https://help.cbp.gov/s/article/Article-1871?language=en_US)


### PR DESCRIPTION
## 🛠 Summary of changes

Adds links back to the Trusted Traveler Program (TTP) help article.

These were originally added in #1257, but were removed over time (#1262, #1280, #1301) due to them becoming invalid links at the DHS website. After some back and forth, the help resources have been restored, and we can add the links back.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1721390880566609

The process for this (reflected in commit history):

1. Restore files from original commit: `git checkout da9cc19 -- content/_help/specific-agencies/trusted-traveler-programs.*`
2. Remove still-invalid link for "Application changes" (this appears to have been rolled into content of "Application status")
3. Update link IDs, since they appear to have changed from the original

## 📜 Testing Plan

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/aduth-add-ttp-links/help/specific-agencies/trusted-traveler-programs/
2. Verify that all links under "Please contact the Trusted Traveler Programs directly if you have questions regarding" go to a valid article corresponding to the link text
3. Repeat these steps for other page languages

## 📸 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/e12fcc14-a387-4368-9b53-207e64ec943d)|![image](https://github.com/user-attachments/assets/5e5e16dd-1909-4dc6-bcd1-19caabecad21)
