### PR TITLE
Pass locale parameter in USPS Post Office search to get localized results

### DIFF
--- a/_includes/components/post-office-search.html
+++ b/_includes/components/post-office-search.html
@@ -3,6 +3,7 @@
   class="find-a-participating-post-office"
   data-address-search-url="{{ site.po_search_address_search_url }}"
   data-locations-search-url="{{ site.po_search_locations_search_url }}"
+  data-page-lang="{{ page.lang }}"
 ></div>
 
 {% assign timestamp = site.time | date: '%s' %}

--- a/_includes/components/post-office-search.html
+++ b/_includes/components/post-office-search.html
@@ -3,7 +3,6 @@
   class="find-a-participating-post-office"
   data-address-search-url="{{ site.po_search_address_search_url }}"
   data-locations-search-url="{{ site.po_search_locations_search_url }}"
-  data-page-lang="{{ page.lang }}"
 ></div>
 
 {% assign timestamp = site.time | date: '%s' %}

--- a/assets/js/post_office_search.tsx
+++ b/assets/js/post_office_search.tsx
@@ -11,7 +11,9 @@ import { UsStatesTerritories } from './form_helper';
 export function render() {
   const elem = document.getElementById('post-office-search')!;
   const root = createRoot(elem);
-  const { locationsSearchUrl } = elem.dataset;
+  const { locationsSearchUrl, pageLang } = elem.dataset;
+  const localizedLocationsSearchUrl = new URL(locationsSearchUrl);
+  localizedLocationsSearchUrl.searchParams.set('locale', pageLang);
 
   root.render(
     <form>
@@ -19,7 +21,7 @@ export function render() {
         noValidate
         disabled={false}
         handleLocationSelect={null}
-        locationsURL={locationsSearchUrl}
+        locationsURL={localizedLocationsSearchUrl}
         noInPersonLocationsDisplay={NoInPersonLocationsDisplay}
         onFoundLocations={() => {}}
         registerField={() => {}}

--- a/assets/js/post_office_search.tsx
+++ b/assets/js/post_office_search.tsx
@@ -8,10 +8,14 @@ import { t } from '@18f/identity-i18n';
 import NoInPersonLocationsDisplay from './no_in_person_locations_display';
 import { UsStatesTerritories } from './form_helper';
 
+interface PostOfficeSearchElementDataset extends DOMStringMap {
+  locationsSearchUrl: string;
+}
+
 export function render() {
   const elem = document.getElementById('post-office-search')!;
   const root = createRoot(elem);
-  const { locationsSearchUrl } = elem.dataset;
+  const { locationsSearchUrl } = elem.dataset as PostOfficeSearchElementDataset;
   const localizedLocationsSearchUrl = new URL(locationsSearchUrl);
   localizedLocationsSearchUrl.searchParams.set('locale', document.documentElement.lang);
 

--- a/assets/js/post_office_search.tsx
+++ b/assets/js/post_office_search.tsx
@@ -11,9 +11,9 @@ import { UsStatesTerritories } from './form_helper';
 export function render() {
   const elem = document.getElementById('post-office-search')!;
   const root = createRoot(elem);
-  const { locationsSearchUrl, pageLang } = elem.dataset;
+  const { locationsSearchUrl } = elem.dataset;
   const localizedLocationsSearchUrl = new URL(locationsSearchUrl);
-  localizedLocationsSearchUrl.searchParams.set('locale', pageLang);
+  localizedLocationsSearchUrl.searchParams.set('locale', document.documentElement.lang);
 
   root.render(
     <form>


### PR DESCRIPTION
## 🛠 Summary of changes

Following the changes in https://github.com/18F/identity-idp/pull/10940, we are more consistent in supporting localized search results. This PR adds the `locale` parameter so that results are translated appropriately.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

## 📸 Screenshots


| Before | After |
| ----------- | ----------- |
| ![image](https://github.com/user-attachments/assets/6a541171-f8ab-4aa5-bd1b-368ea00ae91f) | ![image](https://github.com/user-attachments/assets/650db1c7-fd82-47d7-a95e-1433558cc5c5)   |

