### PR TITLE
Added redirect back that shouldn't have been removed.

### DIFF
--- a/content/_help/verify-your-identity/accepted-identification-documents._en.md
+++ b/content/_help/verify-your-identity/accepted-identification-documents._en.md
@@ -7,6 +7,8 @@ order: 2
 redirect_from:
   - /help/identity-verification/i-do-not-have-a-state-issued-id-can-i-still-verify-my-identity/
   - /help/verifying-your-identity/dont-have-a-state-issued-id/
+  - /help/verify-your-identity/accepted-state-issued-identification/
+  - /en/help/verify-your-identity/accepted-state-issued-identification/
   - /en/help/verify-your-identity/accepted-identification-documents/
 do_list:
   - "**Driver’s license** from all 50 states, the District of Columbia (DC), and other U.S. territories (Guam, U.S. Virgin Islands, American Samoa, Mariana Islands, and Puerto Rico)."

--- a/content/_help/verify-your-identity/accepted-identification-documents._es.md
+++ b/content/_help/verify-your-identity/accepted-identification-documents._es.md
@@ -6,6 +6,7 @@ order: 2
 redirect_from:
   - /es/help/identity-verification/i-do-not-have-a-state-issued-id-can-i-still-verify-my-identity/
   - /es/help/verifying-your-identity/dont-have-a-state-issued-id/
+  - /es/help/verify-your-identity/accepted-state-issued-identification/
 do_list:
   - "**Licencia de conducir** de los 50 estados, el Distrito de Columbia (DC) y otros territorios de los Estados Unidos (Guam, Islas Vírgenes de los EE. UU., Samoa Americana, Islas Marianas y Puerto Rico)."
   - "**Tarjeta de identificación emitida por el estado que no sea una licencia de conducir.** Es un documento de identificación emitido por el estado, el Distrito de Columbia (DC) o un territorio de los EE. UU. que confirma la identidad, pero no otorga privilegios para conducir."

--- a/content/_help/verify-your-identity/accepted-identification-documents._fr.md
+++ b/content/_help/verify-your-identity/accepted-identification-documents._fr.md
@@ -6,6 +6,7 @@ order: 2
 redirect_from:
   - /fr/help/identity-verification/i-do-not-have-a-state-issued-id-can-i-still-verify-my-identity/
   - /fr/help/verifying-your-identity/dont-have-a-state-issued-id/
+  - /fr/help/verify-your-identity/accepted-state-issued-identification/
 do_list:
   - « **Permis de conduire** des 50 États des États-Unis, du District de Columbia (D.C.) et d’autres territoires des États-Unis (Guam, Îles Vierges des États-Unis, Samoa américaines, Îles Mariannes et Porto Rico). »
   - « **Pièce d’identité délivrée par l’État, à l’exception d’un permis de conduire.** Il s'agit d'une pièce d'identité délivrée par un État, le district de Columbia (D.C.) ou un territoire américain, qui atteste de l'identité mais ne donne pas le droit de conduire. »

--- a/content/_help/verify-your-identity/accepted-identification-documents._zh.md
+++ b/content/_help/verify-your-identity/accepted-identification-documents._zh.md
@@ -3,6 +3,8 @@ layout: help
 title: 系统接受的身份证件
 category: verify-your-identity
 permalink: /zh/help/verify-your-identity/accepted-identification-documents/
+redirect_from:
+  - /zh/help/verify-your-identity/accepted-state-issued-identification/
 order: 2
 do_list:
   - "美国所有50个州、哥伦比亚特区（DC）以及其他美国属地（关岛、美属维尔京岛、美属萨摩亚、马里亚纳群岛和波多黎各）的**驾照**。"


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket.
[LG-13945](https://cm-jira.usa.gov/browse/LG-13945)
## 🛠 Summary of changes

Added a redirect for `/help/verify-your-identity/accepted-state-issued-identification` back; it was mistakenly removed.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Bring up the site locally
- [ ] Navigate to `/help/verify-your-identity/accepted-state-issued-identification` and verify that you are redirected to `/help/verify-your-identity/accepted-identification-documents`
- [ ] Navigate to `/en/help/verify-your-identity/accepted-state-issued-identification` and verify that you are redirected to `/help/verify-your-identity/accepted-identification-documents` _nb: the `/en` is removed from the path. English gets special treament._
- [ ] Navigate to `/es/help/verify-your-identity/accepted-state-issued-identification` and verify that you are redirected to `/es/help/verify-your-identity/accepted-identification-documents`
- [ ] Navigate to `/fr/help/verify-your-identity/accepted-state-issued-identification` and verify that you are redirected to `/fr/help/verify-your-identity/accepted-identification-documents`
- [ ] Navigate to `/zh/help/verify-your-identity/accepted-state-issued-identification` and verify that you are redirected to `/zh/help/verify-your-identity/accepted-identification-documents`

