### PR TITLE
Add configuration for Search.gov affiliates for non-English languages (LG-9522)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -162,6 +162,12 @@ plugins:
 
 default_locale: en
 
+search_affiliate:
+  en: 'login.gov'
+  es: 'login.gov_es'
+  fr: 'login.gov_fr'
+  zh: 'login.gov_zh'
+
 redirect_from:
   json: false
 

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -11,7 +11,7 @@
   role="search"
 >
   <input name="utf8" type="hidden" value="&#x2713;" />
-  <input name="affiliate" type="hidden" value="login.gov" />
+  <input name="affiliate" type="hidden" value="{{ site.search_affiliate[page.lang] }}" />
   {% if include.collection %}
     <input name="dc" type="hidden" value="{{ include.collection }}" />
   {% endif %}

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'config' do
+  describe '_config.yml' do
+    it 'has search_affiliate keys for all supported languages' do
+      SITE_CONFIG['languages'].each do |locale|
+        expect(SITE_CONFIG['search_affiliate'][locale]).to_not be_nil
+      end
+    end
+
+    it 'has content keys for all supported languages' do
+      SITE_CONFIG['languages'].each do |locale|
+        expect(SITE_CONFIG['defaults'].count { |x| x.dig('values', 'lang') == locale }).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -18,15 +18,24 @@ RSpec.describe 'data' do
     end
   end
 
+  it 'has directories for each supported language' do
+    SITE_CONFIG['languages'].each do |locale|
+      expect(Dir.exist?("_data/#{locale}")).to eq(true), "#{locale} _data folder does not exist"
+    end
+  end
+
   describe 'language_map.yml' do
     it 'contains language shortcodes and names' do
-      path = '_data/language_map.yml'
-      language_map = YAML.load_file(path)
+      expect(LANGUAGE_MAP_CONFIG['languages']['en']).to eq('English')
+      expect(LANGUAGE_MAP_CONFIG['languages']['es']).to eq('Spanish')
+      expect(LANGUAGE_MAP_CONFIG['languages']['fr']).to eq('French')
+      expect(LANGUAGE_MAP_CONFIG['languages']['zh']).to eq('Simplified Chinese')
+    end
 
-      expect(language_map['languages']['en']).to eq('English')
-      expect(language_map['languages']['es']).to eq('Spanish')
-      expect(language_map['languages']['fr']).to eq('French')
-      expect(language_map['languages']['zh']).to eq('Simplified Chinese')
+    it 'has language map keys for all supported languages' do
+      SITE_CONFIG['languages'].each do |locale|
+        expect(LANGUAGE_MAP_CONFIG['languages'][locale]).to_not be_nil
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,9 @@ end
 
 REPO_ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 SITE_ROOT = Pathname.new(File.expand_path('../../_site', __FILE__))
-SITE_URL = YAML.load_file(File.join(REPO_ROOT, '_config.yml'))['url']
+SITE_CONFIG = YAML.load_file(File.join(REPO_ROOT, '_config.yml'))
+LANGUAGE_MAP_CONFIG = YAML.load_file('_data/language_map.yml')
+SITE_URL = SITE_CONFIG['url']
 SITE_URI = URI(SITE_URL)
 AVAILABLE_LOCALES = YAML.load_file(File.join(REPO_ROOT, '_data/language_map.yml'))['languages'].keys
 AVAILABLE_NON_ENGLISH_LOCALES = AVAILABLE_LOCALES - ['en']


### PR DESCRIPTION
## 🎫 Ticket

[LG-9522](https://cm-jira.usa.gov/browse/LG-9522)


## 🛠 Summary of changes

Currently, we only use the "login.gov" Search.gov affiliate. This is the English affiliate, but we should switch to the relevant one for the current language based on the selected language.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
|  |  |
-->

