### PR TITLE
LG-14155: Update Chinese translation

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -337,7 +337,7 @@ nav:
   privacy_&_security: Privacy & security
   security: Security
   security_experience: Security experience
-  sign_in: 'Sign in with <span>Login.gov</span>'
+  sign_in: 'Sign in with {{APP_NAME}}'
   skip_nav: Skip to main content
   system_status: Login.gov system status
   what_is_login_gov: What is Login.gov?

--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -337,7 +337,7 @@ nav:
   privacy_&_security: Privacy & security
   security: Security
   security_experience: Security experience
-  sign_in: 'Sign in with'
+  sign_in: 'Sign in with <span>Login.gov</span>'
   skip_nav: Skip to main content
   system_status: Login.gov system status
   what_is_login_gov: What is Login.gov?

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -345,7 +345,7 @@ nav:
   privacy_&_security: Privacidad y seguridad
   security: Seguridad
   security_experience: Security experience # partners site does not require translations
-  sign_in: 'Inicie sesión con <span>Login.gov</span>'
+  sign_in: 'Inicie sesión con {{APP_NAME}}'
   skip_nav: Saltar al contenido principal
   system_status: Estado del sistema Login.gov
   what_is_login_gov: ¿Qué es Login.gov?

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -345,7 +345,7 @@ nav:
   privacy_&_security: Privacidad y seguridad
   security: Seguridad
   security_experience: Security experience # partners site does not require translations
-  sign_in: Inicie sesión con
+  sign_in: 'Inicie sesión con <span>Login.gov</span>'
   skip_nav: Saltar al contenido principal
   system_status: Estado del sistema Login.gov
   what_is_login_gov: ¿Qué es Login.gov?

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -359,7 +359,7 @@ nav:
   privacy_&_security: Confidentialité et sécurité
   security: Sécurité
   security_experience: Security experience # partners site does not require translations
-  sign_in: 'Se connecter avec <span>Login.gov</span>'
+  sign_in: 'Se connecter avec {{APP_NAME}}'
   skip_nav: Passer au contenu principal
   system_status: État du système Login.gov
   what_is_login_gov: Qu’est-ce que Login.gov ?

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -359,7 +359,7 @@ nav:
   privacy_&_security: Confidentialité et sécurité
   security: Sécurité
   security_experience: Security experience # partners site does not require translations
-  sign_in: 'Se connecter avec'
+  sign_in: 'Se connecter avec <span>Login.gov</span>'
   skip_nav: Passer au contenu principal
   system_status: État du système Login.gov
   what_is_login_gov: Qu’est-ce que Login.gov ?

--- a/_data/zh/settings.yml
+++ b/_data/zh/settings.yml
@@ -326,7 +326,7 @@ nav:
   privacy_&_security: 隐私与安全
   security: 安全
   security_experience: Security experience # partners site does not require translations
-  sign_in: '使用…登录'
+  sign_in: '使用 <span>Login.gov</span> 登录'
   skip_nav: 跳到主要内容
   system_status: Login.gov 系统状态
   what_is_login_gov: 什么是Login.gov？

--- a/_data/zh/settings.yml
+++ b/_data/zh/settings.yml
@@ -326,7 +326,7 @@ nav:
   privacy_&_security: 隐私与安全
   security: 安全
   security_experience: Security experience # partners site does not require translations
-  sign_in: '使用 <span>Login.gov</span> 登录'
+  sign_in: '使用 {{APP_NAME}} 登录'
   skip_nav: 跳到主要内容
   system_status: Login.gov 系统状态
   what_is_login_gov: 什么是Login.gov？

--- a/_includes/sign_in.html
+++ b/_includes/sign_in.html
@@ -3,6 +3,6 @@
   href="{{ site.idp_base_url }}/{% if page.lang!= 'en' %}{{page.lang}}{% endif %}"
   tabindex="0"
   >
-  {% assign sign_in_text = site.data[page.lang].settings.nav.sign_in | replace: '{{APP_NAME}}', '<span>Login.gov</span>'  %}
+  {% assign sign_in_text = site.data[page.lang].settings.nav.sign_in | replace: '{{APP_NAME}}', '<span>Login.gov</span>' %}
   {{ sign_in_text }}
 </a>

--- a/_includes/sign_in.html
+++ b/_includes/sign_in.html
@@ -3,5 +3,6 @@
   href="{{ site.idp_base_url }}/{% if page.lang!= 'en' %}{{page.lang}}{% endif %}"
   tabindex="0"
   >
-  {{ site.data.[page.lang].settings.nav.sign_in }}
+  {% assign sign_in_text = site.data[page.lang].settings.nav.sign_in | replace: '{{APP_NAME}}', '<span>Login.gov</span>'  %}
+  {{ sign_in_text }}
 </a>

--- a/_includes/sign_in.html
+++ b/_includes/sign_in.html
@@ -2,6 +2,6 @@
   class="{{include.mobile}} usa-button sign-in-logo"
   href="{{ site.idp_base_url }}/{% if page.lang!= 'en' %}{{page.lang}}{% endif %}"
   tabindex="0"
-  >{{ site.data.[page.lang].settings.nav.sign_in }}
-  <span>Login.gov</span>
+  >
+  {{ site.data.[page.lang].settings.nav.sign_in }}
 </a>


### PR DESCRIPTION
## 🎫 Ticket

[LG-14155](https://cm-jira.usa.gov/browse/LG-14155)

Implements a simple solution to rearrange the ordering of Chinese text on a "sign in" button. 

## 🛠 Summary of changes
- Updates the ordering of Chinese text for the "sign in" button at the top righthand corner of the page https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/LG-14155-update-chinese-translation/zh/

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
|  |  |
-->

