### PR TITLE
LG-14286: Expire stale URL parameters (cache & flush values)

### DIFF
--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -408,8 +408,8 @@
     class="usa-form"
   >
     <input type="hidden" name="00NU0000004z90b" id="00NU0000004z90b" value="{{ site.data.language_map.languages[page.lang] | default: 'English' }}" />
-    <input type="hidden" name="{{ site.contact_form_agency }}" id="{{ site.contact_form_agency }}" value="" />
-    <input type="hidden" name="{{ site.contact_form_integration }}" id="{{ site.contact_form_integration }}" value="" />
+    <input type="hidden" name="{{ site.contact_form_agency }}" id="{{ site.contact_form_agency }}" value="" data-for="agency" />
+    <input type="hidden" name="{{ site.contact_form_integration }}" id="{{ site.contact_form_integration }}" value="" data-for="integration" />
     <input type="hidden" name="retURL" value="https://login.gov{{ '/' | locale_url }}" />
     <input type="hidden" name="orgid" value="{{ site.contact_form_orgid }}" />
     <input type="hidden" name="status" id="status" value="New" />

--- a/assets/js/populate_contact_form_agency.js
+++ b/assets/js/populate_contact_form_agency.js
@@ -6,7 +6,7 @@ export function setInputValueFromLocalStorage(key, dataForValue) {
   }
 
   const value = localStorage.getItem(key);
-  const inputElement = document.querySelector(`input[data-for='${dataForValue}'']`);
+  const inputElement = document.querySelector(`input[data-for='${dataForValue}']`);
 
   if (value && inputElement) {
     inputElement.value = value;

--- a/assets/js/populate_contact_form_agency.js
+++ b/assets/js/populate_contact_form_agency.js
@@ -1,12 +1,12 @@
 import { isLocalStorageAvailable } from './storage_availability.js';
 
-export function setInputValueFromLocalStorage(key, inputId) {
+export function setInputValueFromLocalStorage(key, dataForValue) {
   if (!isLocalStorageAvailable()) {
     return;
   }
 
   const value = localStorage.getItem(key);
-  const inputElement = document.getElementById(inputId);
+  const inputElement = document.querySelector(`input[data-for='${dataForValue}'']`);
 
   if (value && inputElement) {
     inputElement.value = value;
@@ -14,6 +14,6 @@ export function setInputValueFromLocalStorage(key, inputId) {
 }
 
 export function populateFormAgencyValues() {
-  setInputValueFromLocalStorage('agency', '00N3d0000013vIB');
-  setInputValueFromLocalStorage('integration', '00N3d0000013vIC');
+  setInputValueFromLocalStorage('agency', 'agency');
+  setInputValueFromLocalStorage('integration', 'integration');
 }

--- a/assets/js/query_params.js
+++ b/assets/js/query_params.js
@@ -1,21 +1,58 @@
 import { isLocalStorageAvailable } from './storage_availability.js';
 
 const ALLOWED_KEYS = Object.freeze(['agency', 'integration']);
+const CACHE_KEY = 'lastParamsUpdate';
+const SEVEN_DAYS_IN_MILLISECONDS = 604800000;
+const CACHE_DURATION = SEVEN_DAYS_IN_MILLISECONDS;
+
+const currentTimeMilliseconds = () => Date.now();
+
+function hasAllowedParams(urlParams, allowedKeys) {
+  return allowedKeys.some((key) => urlParams.has(key));
+}
+
+function isCacheExpired(lastUpdate, currentTime) {
+  const elapsedTime = currentTime - lastUpdate;
+  return !!lastUpdate && elapsedTime > CACHE_DURATION;
+}
+
+function clearStoredParams(allowedKeys, urlParams) {
+  const currentTime = currentTimeMilliseconds();
+  const lastUpdate = localStorage.getItem(CACHE_KEY);
+
+  if (hasAllowedParams(urlParams, allowedKeys) || isCacheExpired(lastUpdate, currentTime)) {
+    allowedKeys.forEach((key) => localStorage.removeItem(key));
+    localStorage.removeItem(CACHE_KEY);
+
+    return true;
+  }
+
+  return false;
+}
 
 export function storeUrlQueryParams(allowedKeys = ALLOWED_KEYS) {
   if (!('URLSearchParams' in window) || !isLocalStorageAvailable()) {
     return;
   }
 
+  let paramsStored = false;
   const urlParams = new URLSearchParams(window.location.search);
+
+  clearStoredParams(allowedKeys, urlParams);
 
   allowedKeys.forEach((key) => {
     const value = urlParams.get(key);
 
     if (value) {
       localStorage.setItem(key, value);
+      paramsStored = true;
     }
   });
+
+  if (paramsStored) {
+    const currentTime = currentTimeMilliseconds();
+    localStorage.setItem(CACHE_KEY, currentTime);
+  }
 }
 
 export function removeUrlQueryParams(keysToRemove = ALLOWED_KEYS) {

--- a/assets/js/query_params.js
+++ b/assets/js/query_params.js
@@ -23,11 +23,7 @@ function clearStoredParams(allowedKeys, urlParams) {
   if (hasAllowedParams(urlParams, allowedKeys) || isCacheExpired(lastUpdate, currentTime)) {
     allowedKeys.forEach((key) => localStorage.removeItem(key));
     localStorage.removeItem(CACHE_KEY);
-
-    return true;
   }
-
-  return false;
 }
 
 export function storeUrlQueryParams(allowedKeys = ALLOWED_KEYS) {

--- a/spec/js/query_params_spec.js
+++ b/spec/js/query_params_spec.js
@@ -98,7 +98,7 @@ describe('URL query parameters', () => {
       setTestUrl('https://test.com/');
       storeUrlQueryParams();
 
-      assert.strictEqual(localStorage.getItem('agency'), 'gsa', 'Agency should still be stored');
+      assert.strictEqual(localStorage.getItem('agency'), 'gsa');
       assert.strictEqual(
         localStorage.getItem(CACHE_KEY),
         initialCacheTime,

--- a/spec/js/query_params_spec.js
+++ b/spec/js/query_params_spec.js
@@ -1,42 +1,126 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { JSDOM } from 'jsdom';
-import { storeUrlQueryParams, removeUrlQueryParams } from '../../assets/js/query_params.js';
-
-function setupTestEnvironment(url) {
-  const dom = new JSDOM('', { url });
-  global.window = dom.window;
-  global.localStorage = dom.window.localStorage;
-  global.URLSearchParams = dom.window.URLSearchParams;
-  return dom;
-}
+import { storeUrlQueryParams } from '../../assets/js/query_params.js';
 
 describe('URL query parameters', () => {
+  const FIXED_TIMESTAMP = 1724339456350;
+  const CACHE_KEY = 'lastParamsUpdate';
+  let originalDateNow;
+  let jsdom;
+
+  function setTestUrl(newUrl = 'https://test.com/') {
+    const url = new URL(newUrl);
+    global.window.history.replaceState({}, '', url);
+  }
+
+  beforeEach(() => {
+    originalDateNow = Date.now;
+    Date.now = () => FIXED_TIMESTAMP;
+
+    jsdom = new JSDOM('', { url: 'https://test.com' });
+    global.window = jsdom.window;
+    global.URLSearchParams = jsdom.window.URLSearchParams;
+    global.localStorage = jsdom.window.localStorage;
+  });
+
+  afterEach(() => {
+    Date.now = originalDateNow;
+
+    jsdom.window.close();
+
+    delete global.window;
+    delete global.URLSearchParams;
+    delete global.localStorage;
+  });
+
   describe('storeUrlQueryParams', () => {
     it('stores permitted query params in localStorage', () => {
-      setupTestEnvironment('https://site.com/?agency=gsa&integration=abc&invalid=ignored');
+      setTestUrl('https://test.com/?agency=gsa&integration=abc&invalid=ignored');
       storeUrlQueryParams();
 
       assert.strictEqual(localStorage.getItem('agency'), 'gsa');
       assert.strictEqual(localStorage.getItem('integration'), 'abc');
+      assert.strictEqual(localStorage.getItem(CACHE_KEY), FIXED_TIMESTAMP.toString());
     });
 
     it('ignores invalid query params', () => {
-      setupTestEnvironment('https://site.com/?agency=gsa&integration=abc&invalid=ignored');
+      setTestUrl('https://test.com/?agency=gsa&integration=abc&invalid=ignored');
       storeUrlQueryParams();
 
       assert.strictEqual(localStorage.getItem('invalid'), null);
     });
-  });
 
-  describe('removeUrlQueryParams', () => {
-    it('removes permitted query params from URL', () => {
-      const dom = setupTestEnvironment(
-        'https://site.com/?agency=gsa&integration=abc&invalid=ignored',
+    it('clears stored params when new params are present', () => {
+      setTestUrl('https://test.com/?agency=gsa');
+      storeUrlQueryParams();
+
+      assert.strictEqual(localStorage.getItem('agency'), 'gsa');
+
+      setTestUrl('https://test.com/?integration=abc');
+      storeUrlQueryParams();
+
+      assert.strictEqual(localStorage.getItem('agency'), null);
+      assert.strictEqual(localStorage.getItem('integration'), 'abc');
+    });
+
+    it('clears stored params when cache is expired', () => {
+      setTestUrl('https://test.com/?agency=gsa');
+      storeUrlQueryParams();
+
+      assert.strictEqual(localStorage.getItem('agency'), 'gsa');
+
+      const EIGHT_DAYS = 691200000;
+      Date.now = () => FIXED_TIMESTAMP + EIGHT_DAYS;
+
+      setTestUrl('https://test.com/');
+      storeUrlQueryParams();
+
+      assert.strictEqual(localStorage.getItem('agency'), null);
+      assert.strictEqual(localStorage.getItem(CACHE_KEY), null);
+    });
+
+    it('does not clear stored params when cache is not expired and no new params', () => {
+      setTestUrl('https://test.com/?agency=gsa');
+      storeUrlQueryParams();
+
+      assert.strictEqual(
+        localStorage.getItem('agency'),
+        'gsa',
+        'Agency should be stored initially',
       );
-      removeUrlQueryParams();
 
-      assert.strictEqual(dom.window.location.href, 'https://site.com/?invalid=ignored');
+      const initialCacheTime = localStorage.getItem(CACHE_KEY);
+      const SIX_DAYS = 518400000;
+      const newTime = FIXED_TIMESTAMP + SIX_DAYS;
+      Date.now = () => newTime;
+
+      setTestUrl('https://test.com/');
+      storeUrlQueryParams();
+
+      assert.strictEqual(localStorage.getItem('agency'), 'gsa', 'Agency should still be stored');
+      assert.strictEqual(
+        localStorage.getItem(CACHE_KEY),
+        initialCacheTime,
+        'Cache time should not change',
+      );
+    });
+
+    it('updates cache key only when new params are stored', () => {
+      setTestUrl('https://test.com/?agency=gsa');
+      storeUrlQueryParams();
+      const initialCacheTime = localStorage.getItem(CACHE_KEY);
+
+      setTestUrl('https://test.com/?agency=gsa');
+      storeUrlQueryParams();
+
+      assert.strictEqual(localStorage.getItem(CACHE_KEY), initialCacheTime);
+
+      Date.now = () => FIXED_TIMESTAMP + 1000;
+      setTestUrl('https://test.com/?integration=new');
+      storeUrlQueryParams();
+
+      assert.notStrictEqual(localStorage.getItem(CACHE_KEY), initialCacheTime);
     });
   });
 });


### PR DESCRIPTION
## 🎫 Ticket

[LG-14286](https://cm-jira.usa.gov/browse/LG-14286)

## 🛠 Summary of changes

A staging instance can be found at:
- https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/LG-14286-expire-stale-parameters/contact/

Hit the URL with params to store the parameters for the form:
- https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/LG-14286-expire-stale-parameters/contact/?agency=agency1&integration=integration1

Refresh the page and notice that the params are stored in hidden values on the form.

Advance your computer's date 8+ days (if possible) and refresh the page. The parameters will now be cleared from localStorage and the hidden fields on the form.
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
|  |  |
-->

