### PR TITLE
LG-14223 | Use icon bullets on "Verify your phone number" page

### DIFF
--- a/content/_help/verify-your-identity/phone-number._en.md
+++ b/content/_help/verify-your-identity/phone-number._en.md
@@ -9,23 +9,29 @@ redirect_from:
   - /en/help/verify-your-identity/phone-number/
   - /help/verify-your-identity/phone-number-and-phone-plan-in-your-name/
   - /help/verifying-your-identity/phone-plan-is-not-in-my-name-or-address/
+can_verify_list:
+  - Home number
+  - Work number
+  - Cell or mobile number
+  - Landline number
+cannot_verify_list:
+  - International numbers and numbers in some U.S. territories
+  - Google Voice or similar VoIP (Voice over Internet Protocol) numbers
+  - Premium rate (toll) numbers
 ---
 We match your phone number with records to verify your identity. The phone number that you use to verify your identity must be based in the United States.
 
 We are most likely to successfully verify your identity if you enter your primary number (the number that you use most often).
 
 ## You can verify your identity with your:
-- Home number
-- Work number
-- Cell or mobile number
-- Landline number
+
+{% include components/icon-list.html items=page.can_verify_list size='md' icon_color='success' icon_shape='check_circle'%}
 
 You can use a prepaid cell phone to verify your identity. However, some prepaid phone numbers contain risk factors that might cause you to fail identity verification.
 
 ## You cannot verify your identity with:
-- International numbers and numbers in some U.S. territories
-- Google voice or similar VoIP (Voice over Internet Protocol) numbers
-- Premium rate (toll) numbers
+
+{% include components/icon-list.html items=page.cannot_verify_list size='md' icon_color='error' icon_shape='cancel' %}
 
 ## If you cannot complete this step
 In some cases, you may be able to select “Verify your address by mail instead.” You will have to wait 5 to 10 days to receive a letter in the mail and then follow the instructions to enter the verification code.

--- a/content/_help/verify-your-identity/phone-number._es.md
+++ b/content/_help/verify-your-identity/phone-number._es.md
@@ -6,23 +6,29 @@ order: 5
 redirect_from:
   - /es/help/verifying-your-identity/phone-plan-is-not-in-my-name-or-address/
   - /es/help/verify-your-identity/phone-number-and-phone-plan-in-your-name/
+can_verify_list:
+  - Número de casa
+  - Número del trabajo
+  - Número de teléfono móvil
+  - Número de teléfono fijo
+cannot_verify_list:
+  - Números internacionales y números en algunos territorios de EE.UU.
+  - Números de teléfono de Google Voice o de voz sobre protocolo de internet (VoIP) similares
+  - Números de tarifa especial
 ---
 Comparamos su número de teléfono con los registros para verificar su identidad. El número de teléfono que use para verificar su identidad debe ser de los Estados Unidos.
 
 Si ingresa su número principal (el que usa más a menudo), es más probable que logremos verificar su identidad.
 
 ## Puede verificar su identidad con su:
-- Número de casa
-- Número del trabajo
-- Número de teléfono móvil
-- Número de teléfono fijo
+
+{% include components/icon-list.html items=page.can_verify_list size='md' icon_color='success' icon_shape='check_circle'%}
 
 Puede utilizar un teléfono celular de prepago para verificar su identidad. Sin embargo, algunos números de teléfono de prepago tienen factores de riesgo que pueden impedir la verificación de su identidad.
 
 ## No puede verificar su identidad con:
-- Números internacionales y números en algunos territorios de EE.UU.
-- Números de teléfono de Google Voice o de voz sobre protocolo de internet (VoIP) similares
-- Números de tarifa especial
+
+{% include components/icon-list.html items=page.cannot_verify_list size='md' icon_color='error' icon_shape='cancel' %}
 
 ## Si no puede efectuar este paso:
 

--- a/content/_help/verify-your-identity/phone-number._fr.md
+++ b/content/_help/verify-your-identity/phone-number._fr.md
@@ -6,23 +6,29 @@ order: 5
 redirect_from:
   - /fr/help/verifying-your-identity/phone-plan-is-not-in-my-name-or-address/
   - /fr/help/verify-your-identity/phone-number-and-phone-plan-in-your-name/
+can_verify_list:
+  - Numéro personnel
+  - Numéro professionnel
+  - Numéro de téléphone portable
+  - Numéro de téléphone fixe
+cannot_verify_list:
+  - Des numéros internationaux et des numéros de certains territoires américains
+  - Numéros Google Voice ou VOIP (voix sur IP) similaires
+  - Les numéros surtaxés (payants)
 ---
 Nous comparons votre numéro de téléphone aux données enregistrées pour vérifier votre identité. Le numéro de téléphone que vous utilisez pour confirmer votre identité doit être basé aux États-Unis.
 
 Nous pouvons plus facilement vérifier votre identité si vous saisissez votre numéro principal (le numéro que vous utilisez le plus souvent).
 
 ## Vous pouvez vérifier votre identité à l’aide de votre :
-- Numéro personnel
-- Numéro professionnel
-- Numéro de téléphone portable
-- Numéro de téléphone fixe
+
+{% include components/icon-list.html items=page.can_verify_list size='md' icon_color='success' icon_shape='check_circle'%}
 
 Vous pouvez utiliser un téléphone portable prépayé pour vérifier votre identité. Cependant, certains numéros de téléphone prépayés contiennent des facteurs de risque qui peuvent compromettre la vérification de votre identité.
 
 ## Vous ne pouvez pas vérifier votre identité avec :
-- Des numéros internationaux et des numéros de certains territoires américains
-- Numéros Google Voice ou VOIP (voix sur IP) similaires
-- Les numéros surtaxés (payants)
+
+{% include components/icon-list.html items=page.cannot_verify_list size='md' icon_color='error' icon_shape='cancel' %}
 
 ## Si vous ne pouvez pas effectuer cette étape
 

--- a/content/_help/verify-your-identity/phone-number._zh.md
+++ b/content/_help/verify-your-identity/phone-number._zh.md
@@ -4,23 +4,29 @@ title: 验证你的电话号码
 category: verify-your-identity
 permalink: /zh/help/verify-your-identity/phone-number/
 order: 5
+can_verify_list:
+  - 家庭电话号码
+  - 工作电话号码
+  - 手机号码
+  - 座机电话号码
+cannot_verify_list:
+  - 国际电话号码以及有些美国属地的号码
+  - 谷歌语音或类似VoIP（基于IP的语音传输）号码
+  - 高价（收费）电话号码
 ---
 我们通过把你的电话号码与记录进行核对来验证你的身份。你用来验证身份的电话号码必须是美国国内的电话号码。
 
 如果你输入主电话号码（即你最常用的号码），我们就最可能成功验证你的身份。
 
 ## 你可以使用以下信息来验证身份：
-- 家庭电话号码
-- 工作电话号码
-- 手机号码
-- 座机电话号码
+
+{% include components/icon-list.html items=page.can_verify_list size='md' icon_color='success' icon_shape='check_circle'%}
 
 你也可以使用预付费手机来验证身份。但是，某些预付费电话号码可能包含导致你身份验证失败的风险因素。
 
 ## 你不能使用以下信息来验证身份：
-- 国际电话号码以及有些美国属地的号码
-- 谷歌语音或类似VoIP（基于IP的语音传输）号码
-- 高价（收费）电话号码
+
+{% include components/icon-list.html items=page.cannot_verify_list size='md' icon_color='error' icon_shape='cancel' %}
 
 ## 如果你无法完成这一步：
 在某些情况下，您可能可以选择“改用邮局信件验证您的地址”。你得等 5 到 10 天才能收到邮寄的信件，收到后请按照其中指示输入验证码。


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket.
[LG-14223](https://cm-jira.usa.gov/browse/LG-14223)

## 🛠 Summary of changes

Quoth the Jira:

> As a Login.gov user, I want to see a help article that clearly shows me the phone numbers I can and cannot use to verify my identity and that matches the icon bullets on other help articles on the site, so that I can feel confident in the information.

It is also my (completely unimportant) opinion that these make the page look much better, as an aside.

## 📸 Screenshots

[English](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/mattw/LG-14223-verify-icons/help/verify-your-identity/phone-number/) &middot; [French](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/mattw/LG-14223-verify-icons/fr/help/verify-your-identity/phone-number/) &middot; [Spanish](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/mattw/LG-14223-verify-icons/es/help/verify-your-identity/phone-number/) &middot; [Chinese](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/gsa-tts/identity-site/mattw/LG-14223-verify-icons/zh/help/verify-your-identity/phone-number/)

