### PR TITLE
Don't use import.meta.dirname in webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
-const { NODE_ENV = 'production' } = process.env;
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const { dirname } = import.meta;
+const { NODE_ENV = 'production' } = process.env;
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default /** @type {import('webpack').Configuration} */ ({
   mode: NODE_ENV,
@@ -17,7 +19,7 @@ export default /** @type {import('webpack').Configuration} */ ({
   target: ['web'],
   output: {
     filename: '[name].js',
-    path: `${dirname}/_site/assets/js`,
+    path: `${__dirname}/_site/assets/js`,
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const { NODE_ENV = 'production' } = process.env;
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const webpackConfigDir = dirname(fileURLToPath(import.meta.url));
 
 export default /** @type {import('webpack').Configuration} */ ({
   mode: NODE_ENV,
@@ -19,7 +19,7 @@ export default /** @type {import('webpack').Configuration} */ ({
   target: ['web'],
   output: {
     filename: '[name].js',
-    path: `${__dirname}/_site/assets/js`,
+    path: `${webpackConfigDir}/_site/assets/js`,
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx'],


### PR DESCRIPTION
Looks like `import.meta.dirname` was added in a point release in the Nodejs v20 series.

We are requiring "20" as a version, so some compatible versions won't work without this.
