### PR TITLE
Use CircleCI orbs to install Node.js and Node/Ruby dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,31 +2,15 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.2
+  node: circleci/node@6.3.0
+  ruby: circleci/ruby@2.3.0
+
 commands:
   install-dependencies:
     steps:
-      - restore_cache:
-          keys:
-            - dependencies-{{ checksum "package-lock.json" }}-{{ checksum "Gemfile.lock" }}
-      - run:
-          name: Switch Node.js version
-          command: |
-            wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
-            export NVM_DIR="$HOME/.nvm"
-            . "$NVM_DIR/nvm.sh" --install --latest-npm
-            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV;
-            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV;
-      - run:
-          name: install dependencies
-          command: |
-            npm ci
-            bundle config set --local path 'vendor/bundle'
-            bundle install --jobs=4 --retry=3
-      - save_cache:
-          paths:
-            - ~/.npm
-            - ./vendor/bundle
-          key: dependencies-{{ checksum "package-lock.json" }}-{{ checksum "Gemfile.lock" }}
+      - node/install
+      - node/install-packages
+      - ruby/install-deps
   build-site:
     steps:
       - run:


### PR DESCRIPTION
## 🛠 Summary of changes

Updates CircleCI configuration to take advantage of CircleCI official orb command helpers for managing installation of Node.js and Node.js/Ruby dependencies.

**Why?**

- The current setup procedure is rather unstable, particularly at downloading Node.js. It's hoped that CircleCI may have better built-in tolerances for this (version caching, retry, etc.)
- It greatly simplifies the code, and avoids sketchy `wget | bash` piping
- Brings into alignment with other CircleCI-based Login.gov projects, specifically [`identity-dev-docs`](https://github.com/GSA-TTS/identity-dev-docs/blob/main/.circleci/config.yml) (h/t @monfresh for introducing these changes in https://github.com/GSA-TTS/identity-dev-docs/pull/477)

Reference documentation:

- https://circleci.com/developer/orbs/orb/circleci/node#commands
   - `node/install` will respect NVM:
     >`node-version` [...] If unspecified, the version listed in `.nvmrc` or `.node-version` will be installed.
   - `node/install-packages` will cache dependencies:
     >Install your Node packages with automated caching and best practices applied 
- https://circleci.com/developer/orbs/orb/circleci/ruby#commands
   - `ruby/install-packages` will cache dependencies:
     >Easily cache and install your Ruby Gems automatically

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1730290346015499

## 📜 Testing Plan

Verify build passes.