### PR TITLE
LG-11857: add header post office search results

### DIFF
--- a/assets/js/post_office_search.tsx
+++ b/assets/js/post_office_search.tsx
@@ -42,6 +42,7 @@ export function render() {
           </Alert>
         )}
         usStatesTerritories={UsStatesTerritories}
+        resultsSectionHeading={() => <h2>Search results for Post Offices near you</h2>}
       />
     </form>,
   );

--- a/assets/js/post_office_search.tsx
+++ b/assets/js/post_office_search.tsx
@@ -42,7 +42,9 @@ export function render() {
           </Alert>
         )}
         usStatesTerritories={UsStatesTerritories}
-        resultsSectionHeading={() => <h2>Search results for Post Offices near you</h2>}
+        resultsSectionHeading={() => (
+          <h2>{t('in_person_proofing.body.location.po_search.results_heading')}</h2>
+        )}
       />
     </form>,
   );

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._en.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._en.md
@@ -10,6 +10,7 @@ translations:
   in_person_proofing.body.location.po_search.you_must_start.link_text: 'Learn more about verifying your identity in person.'
   in_person_proofing.body.location.po_search.you_must_start.link: /help/verify-your-identity/verify-your-identity-in-person/
   in_person_proofing.body.location.po_search.you_must_start.message: 'You must start this process on %{app_name} before going to the Post Office.'
+  in_person_proofing.body.location.po_search.results_heading: 'Search results for Post Offices near you'
 ---
 
 {% include components/post-office-search.html %}

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._es.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._es.md
@@ -10,6 +10,7 @@ translations:
   in_person_proofing.body.location.po_search.you_must_start.link_text: 'Obtenga más información sobre cómo verificar su identidad en persona.'
   in_person_proofing.body.location.po_search.you_must_start.link: /es/help/verify-your-identity/verify-your-identity-in-person/
   in_person_proofing.body.location.po_search.you_must_start.message: 'Debe iniciar este proceso en %{app_name} antes de acudir a la oficina de correos.'
+  in_person_proofing.body.location.po_search.results_heading: 'Buscar resultados de Oficinas de correos cercanas'
 ---
 
 {% include components/post-office-search.html %}

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._fr.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._fr.md
@@ -10,6 +10,8 @@ translations:
   in_person_proofing.body.location.po_search.you_must_start.link_text: 'En savoir plus sur la vérification de votre identité en personne.'
   in_person_proofing.body.location.po_search.you_must_start.link: /fr/help/verify-your-identity/verify-your-identity-in-person/
   in_person_proofing.body.location.po_search.you_must_start.message: 'Vous devez commencer cette procédure sur %{app_name} avant de vous rendre au bureau de poste.'
+  in_person_proofing.body.location.po_search.results_heading: 'Résultats de la recherche pour des bureaux de poste près de vous'
+
 ---
 
 {% include components/post-office-search.html %}

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._zh.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._zh.md
@@ -10,6 +10,8 @@ translations:
   in_person_proofing.body.location.po_search.you_must_start.link_text: '了解更多有关亲身去验证身份的信息。'
   in_person_proofing.body.location.po_search.you_must_start.link: /zh/help/verify-your-identity/verify-your-identity-in-person/
   in_person_proofing.body.location.po_search.you_must_start.message: '去邮局之前就在 %{app_name} 开始这一流程'
+  in_person_proofing.body.location.po_search.results_heading: '您附近邮局的搜索结果'
+
 ---
 
 {% include components/post-office-search.html %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@18f/identity-address-search": "^3.2.0",
+        "@18f/identity-address-search": "^3.4.0",
         "@18f/identity-build-sass": "^3.0.0",
         "@18f/identity-components": "^2.0.0",
         "@18f/identity-design-system": "^9.0.0",
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@18f/identity-address-search": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-address-search/-/identity-address-search-3.2.0.tgz",
-      "integrity": "sha512-1qp0iNogyx0oY/bOE0C3yxfi93NzWMRNywBIWrx4JBbgkUuLcos+pFzvlnMOc1/uRSV1fq4hYuyJ1W/IGJmVRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-address-search/-/identity-address-search-3.4.0.tgz",
+      "integrity": "sha512-YBB5+VJOTiG5ZKtmeAgIU9tBwE94fgBKj7qYtCf5WNiHcGixcq0BwS4j8xaiOyOGVn8mqAwwd4lbF8suswR1Bg==",
       "dependencies": {
         "focus-trap": "^6.7.1",
         "swr": "^2.0.0"
@@ -11696,9 +11696,9 @@
       }
     },
     "@18f/identity-address-search": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-address-search/-/identity-address-search-3.2.0.tgz",
-      "integrity": "sha512-1qp0iNogyx0oY/bOE0C3yxfi93NzWMRNywBIWrx4JBbgkUuLcos+pFzvlnMOc1/uRSV1fq4hYuyJ1W/IGJmVRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-address-search/-/identity-address-search-3.4.0.tgz",
+      "integrity": "sha512-YBB5+VJOTiG5ZKtmeAgIU9tBwE94fgBKj7qYtCf5WNiHcGixcq0BwS4j8xaiOyOGVn8mqAwwd4lbF8suswR1Bg==",
       "requires": {
         "focus-trap": "^6.7.1",
         "swr": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vnu-jar": "^21.10.12"
   },
   "dependencies": {
-    "@18f/identity-address-search": "^3.2.0",
+    "@18f/identity-address-search": "^3.4.0",
     "@18f/identity-build-sass": "^3.0.0",
     "@18f/identity-components": "^2.0.0",
     "@18f/identity-design-system": "^9.0.0",


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket.
[11857](https://cm-jira.usa.gov/browse/LG-11857)

## 🛠 Summary of changes

Utilized a new prop in the `FullAddressSearch` component to display a header on top of the post office search results 

## 📜 Testing Plan

- [x] Start up the application and navigate to the post office search [page](http://localhost:4000/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/)
- [x] Run the search
- [x] Notice the new header `Search results for Post Offices near you` that does not exist in main / any higher environment


## 📸 Screenshots

### English
![help-center-PO-Search-heading--en](https://github.com/user-attachments/assets/2b4555dc-55ba-441c-98a4-ae6350cf6efe)

### Spanish
![help-center-PO-Search-heading--es](https://github.com/user-attachments/assets/9147b727-b398-44d3-938f-206ae5146c50)

### French
![help-center-PO-Search-heading--fr](https://github.com/user-attachments/assets/c9036099-986b-40c7-993b-d4cd9380ea24)

### Chinese
![help-center-PO-Search-heading--zh](https://github.com/user-attachments/assets/0fb28136-3f32-402e-879d-856924dc9459)
