### PR TITLE
Update Steps in the README To Get USPS Mock Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,7 @@ You can then view the site in your browser at http://localhost:4000 .
 
 To get mock data for Post Office Search:
 
-Update identity-idp config/application.yml with:
-
-```
-in_person_public_address_search_enabled: true
-```
-
-Then, start identity-idp server locally:
+Start identity-idp server locally:
 
 ```
 make run


### PR DESCRIPTION
## 🎫 Ticket
There is not a ticket. I will create one upon upon request 

## 🛠 Summary of changes
- I updated the README to remove a step that is no longer needed to obtain mock data. The feature flag was removed in idp, [PR #11370](https://github.com/18F/identity-idp/pull/11370). I noticed it today while testing [PR# 1391](https://github.com/GSA-TTS/identity-site/pull/1391)

## 📜 Testing Plan
- [ ] Step 1 Open the README. Follow instructions "To get mock data for Post Office Search" to ensure the instructions are accurate and that you can successfully get mock data back locally.


## 📸 Screenshots

| Before | After |
| ----------- | ----------- |
|  ![Screenshot 2024-11-15 at 3 05 37 PM](https://github.com/user-attachments/assets/e4f74b11-3e10-4397-9137-f172d8f84063) | <img width="404" alt="Screenshot 2024-11-15 at 3 22 02 PM" src="https://github.com/user-attachments/assets/af9956b1-bcf6-4770-8729-553ef009c82b">  |


