### PR TITLE
Add Microsoft & SSA domains to external URL ignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
           at: '.'
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore congress.gov --url-ignore lastpass.com --url-ignore zendesk.login.gov --url-ignore apps.microsoft.com
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore congress.gov --url-ignore lastpass.com --url-ignore zendesk.login.gov --url-ignore apps.microsoft.com --url-ignore faq.ssa.gov
       - slack/status:
           fail_only: true
           failure_message: ':login-gov::red_circle: external link check failed'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
           at: '.'
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore congress.gov --url-ignore lastpass.com --url-ignore zendesk.login.gov --url-ignore https://secure.login.gov/zh
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore congress.gov --url-ignore lastpass.com --url-ignore zendesk.login.gov --url-ignore apps.microsoft.com
       - slack/status:
           fail_only: true
           failure_message: ':login-gov::red_circle: external link check failed'


### PR DESCRIPTION
## 🛠 Summary of changes

Ignores URL failures for external link check to apps.microsoft.com and faq.ssa.gov domains.

These URLs are currently causing failures, despite working in the browser.

Also removes (replaces) ignored URL for Chinese-language secure.login.gov . This was presumably added prior to the launch of this language, which is now generally available.

## 📜 Testing Plan

Verify build passes.