### PR TITLE
Fix capitalization of Developers.login.gov

### DIFF
--- a/_includes/partners/header.html
+++ b/_includes/partners/header.html
@@ -4,7 +4,7 @@
       <a class="usa-nav__link usa-link" href="{{site.baseurl}}/"> Login.gov </a>
       <span class="links-separator">&#124;</span>
       <a class="usa-nav__link usa-link" href="https://developers.login.gov">
-        Developers.login.gov
+        developers.login.gov
       </a>
     </div>
   </div>


### PR DESCRIPTION
## 🛠 Summary of changes

Noticed that we're inconsistent with our capitalization of developers.login.gov during a presentation that was displaying the partner page today. This changes it to be consistent.

![image](https://github.com/user-attachments/assets/4e6f6559-7c7d-464f-8307-fccb54e6e57c)
![image](https://github.com/user-attachments/assets/7e690c93-52b2-4b3d-b0d8-8698215abd86)


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
|  |  |
-->

